### PR TITLE
Make serve script more portable

### DIFF
--- a/serve
+++ b/serve
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # use uv to run mkdocs with mkdocs-material and its dependencies installed
 uv tool run --with-requirements ./requirements.txt mkdocs ${@:-serve}


### PR DESCRIPTION
`bash` is not guaranteed to be in `/bin`. Use the more portable `/usr/bin/env bash` instead.