### PR TITLE
consistent internal links

### DIFF
--- a/docs/access/index.md
+++ b/docs/access/index.md
@@ -4,7 +4,7 @@ This documentation guides users through the process of accessing CSCS systems an
 
 !!! note ""
     Before accessing CSCS, you need to have an account at CSCS, and be part of a project that has been allocated resources.
-    More information on how to get an account is available in [accounts and projects][account-management].
+    More information on how to get an account is available in [accounts and projects][ref-account-management].
 
 <div class="grid cards" markdown>
 
@@ -12,24 +12,24 @@ This documentation guides users through the process of accessing CSCS systems an
 
     Before signing in to CSCS' web portals or using SSH, all users have to set up multi factor authentification (MFA)
 
-    [:octicons-arrow-right-24: MFA][mfa]
+    [:octicons-arrow-right-24: MFA][ref-mfa]
 
 -   :fontawesome-solid-layer-group: __Web Services__
 
     Before signing in to CSCS' web portals or using SSH, all users have to set up multi factor authentification (MFA)
 
-    [:octicons-arrow-right-24: Accessing CSCS web services][access-web]
+    [:octicons-arrow-right-24: Accessing CSCS web services][ref-access-web]
 
 -   :fontawesome-solid-layer-group: __SSH Access__
 
     Logging into Clusters on Alps
 
-    [:octicons-arrow-right-24: SSH][access-ssh]
+    [:octicons-arrow-right-24: SSH][ref-ssh]
 
 -   :fontawesome-solid-layer-group: __VSCode__
 
     How to connect VSCode IDE on your laptop with Alps
 
-    [:octicons-arrow-right-24: SSH][access-vscode]
+    [:octicons-arrow-right-24: SSH][ref-access-vscode]
 
 </div>

--- a/docs/access/mfa.md
+++ b/docs/access/mfa.md
@@ -1,4 +1,4 @@
-[](){#mfa}
+[](){#ref-mfa}
 # Multi Factor Authentification
 
 To access CSCS services and systems users are required to authenticate using multi-factor authentication (MFA).
@@ -10,7 +10,7 @@ An OTP is a six-digit number which changes every 30 seconds.
 OTPs are generated using a tool installed on a device other than the one used to access CSCS services and infrastructure.
 We recommend to use a smartphone with an application such as Google Authenticator to obtain the OTPs.
 
-[](){#mfa-setup}
+[](){#ref-mfa-setup}
 ## Getting Started
 
 When you first log in to any of the CSCS web applications such as UMP, Jupyter, etc., you will be asked to register your device.
@@ -36,7 +36,7 @@ You can download Google Authenticator for your phone:
 * :fontawesome-brands-android: Android: on the [Google Play Store](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2).
 * :fontawesome-brands-apple: iOS: on the [Apple Store](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2).
 
-[](){#mfa-configure-otp}
+[](){#ref-mfa-configure-otp}
 ### Configure the Authenticator
 
 Before starting, ensure that the following pre-requisites are satisfied
@@ -78,7 +78,7 @@ In case users lose access to their mobile device/Authenticator OTP, users can re
 2. From the login screen, click the "Reset OTP" link below the "LOG IN" button
 3. Enter your username and password.
 4. On successful validation of user credentials, users will receive an email with a reset credentials link like the one below, click on the link in the email
-5. The steps are the same as for the first time you [configured the authenticator][mfa-configure-otp].
+5. The steps are the same as for the first time you [configured the authenticator][ref-mfa-configure-otp].
 
 !!! warning
     When replacing your smartphone remember to sync the authenticator app before resetting the old smartphone.

--- a/docs/access/ssh.md
+++ b/docs/access/ssh.md
@@ -1,9 +1,9 @@
-[](){#access-ssh}
+[](){#ref-ssh}
 # Using SSH
 
-Before accessing CSCS clusters using SSH, first ensure that you have [created a user account][account-management] that is part of a project that has access to the cluster, and have [multi factor authentification][mfa] configured.
+Before accessing CSCS clusters using SSH, first ensure that you have [created a user account][ref-account-management] that is part of a project that has access to the cluster, and have [multi factor authentification][ref-mfa] configured.
 
-[](){#sshservice}
+[](){#ref-ssh-service}
 ## Generating Keys with SSHService
 
 It is not possible to authenticate with a username/password and user-created SSH keys.
@@ -103,7 +103,7 @@ ssh -i ~/.ssh/cscs-key ela.cscs.ch
 To log into a target system at CSCS, you need to perform some additional setup to handle forwarding of SSH keys generated using the SSHService.
 There are two alternatives detailed below.
 
-[](){#ssh-ssh-config}
+[](){#ref-ssh-config}
 ### Adding Ela as a jump host in SSH Configuration
 
 This approach configures Ela as a jump host and creates aliases for the systems that you want to access in `~/.ssh/config` on your laptop or PC.
@@ -148,12 +148,12 @@ After saving this file, one can directly log into `daint.alps.cscs.ch` from your
 ssh daint
 ```
 
-[](){#ssh-ssh-agent}
+[](){#ref-ssh-agent}
 ### Using SSH Agent
 
 Alternatively, the [SSH authentification agent](https://www.ssh.com/academy/ssh/add-command) can be configured to manage the keys.
 
-Each time a new key is generated using the [SSHService][sshservice], add the key to the SSH agent:
+Each time a new key is generated using the [SSHService][ref-ssh-service], add the key to the SSH agent:
 ```
 ssh-add -t 1d ~/.ssh/cscs-key
 ```

--- a/docs/access/vscode.md
+++ b/docs/access/vscode.md
@@ -1,4 +1,4 @@
-[](){#access-vscode}
+[](){#ref-access-vscode}
 # Connecting with VSCode
 
 [Visual Studio Code](https://code.visualstudio.com/) provides flexible support for remote development.
@@ -107,7 +107,7 @@ Once the tunnel is configured, you can access it from VSCode.
 
 !!! warning
     If you plan to do any intensive work: repeated compilation of large projects or running python code in Jupyter, please see the guide to running on a compute node below.
-    Running intensive workloads on login nodes, which are shared resources between all users, is against CSCS [fair usage][policies-fair-use] of Shared Resources policy.
+    Running intensive workloads on login nodes, which are shared resources between all users, is against CSCS [fair usage][ref-policies-fair-use] of Shared Resources policy.
 
 ### Using with containers
 

--- a/docs/access/web.md
+++ b/docs/access/web.md
@@ -1,14 +1,14 @@
-[](){#access-web}
+[](){#ref-access-web}
 # Accessing CSCS Web Portals
 
 Most services at CSCS are connected to the CSCS Single Sign-On gate.
 This gives users the comfort of not having to sign in multiple times in each individual service connected to this gate and increases security.
 Furthermore, the Single Sign-On gate allow users to recover their forgotten passwords and authenticate using a third-party account. The login page looks like
 
-[](){#web-mfa}
+[](){#ref-web-mfa}
 ## Using MFA to acccess web-based services
 
-After having completed the setup of [MFA][mfa], you will be asked to enter your login/password and the OTP to access all web-based services.
+After having completed the setup of [MFA][ref-mfa], you will be asked to enter your login/password and the OTP to access all web-based services.
 
 Enter username and password.
 

--- a/docs/accounts/index.md
+++ b/docs/accounts/index.md
@@ -1,4 +1,4 @@
-[](){#account-management}
+[](){#ref-account-management}
 # Getting and Managing Accounts
 
 Users at CSCS have one account that can be used to access all services and systems at CSCS.
@@ -22,11 +22,11 @@ PIs can then invite members of their groups to join their project.
 
 The tool used to manage projects and accounts depends on the platform on which the project was granted:
 
-* The [HPC Platform][hpcp] and [Climate and Weather Platform][cwp] use the [account and resources management tool][ump] at [account.cscs.ch](https://account.cscs.ch)
-* The [Machine Learning Platform][mlp] uses the [project and resources management tool][waldur] at [portal.cscs.ch](https://portal.cscs.ch).
+* The [HPC Platform][ref-platform-hpcp] and [Climate and Weather Platform][ref-platform-cwp] use the [account and resources management tool][ref-account-ump] at [account.cscs.ch](https://account.cscs.ch)
+* The [Machine Learning Platform][ref-platform-mlp] uses the [project and resources management tool][ref-account-waldur] at [portal.cscs.ch](https://portal.cscs.ch).
 
 !!! note
-    The [portal.cscs.ch][waldur] site will be used to manage all projects in the future.
+    The [portal.cscs.ch][ref-account-waldur] site will be used to manage all projects in the future.
 
 ## Signing up for a new account
 

--- a/docs/accounts/ump.md
+++ b/docs/accounts/ump.md
@@ -1,4 +1,4 @@
-[](){#ump}
+[](){#ref-account-ump}
 # Account and Resources Management Tool
 
 The Swiss National Supercomputing Centre (CSCS) offers a web-based tool for users to manage their accounts and projects at [account.cscs.ch](https://account.cscs.ch).

--- a/docs/accounts/waldur.md
+++ b/docs/accounts/waldur.md
@@ -1,11 +1,11 @@
-[](){#waldur}
+[](){#ref-account-waldur}
 # The Project and Resources Management Tool
 
 CSCS Account Managers, PIs and deputy PIs can invite users to the respective projects following the below steps on CSCS's new project management portal.
 
 !!! info
-    The new user project management portal is currently only used by the [Machine Learning Platform][mlp]
-    All other platforms use the old [user management portal](ump.md)
+    The new user project management portal is currently only used by the [Machine Learning Platform][ref-platform-mlp]
+    All other platforms use the old [user management portal][ref-account-ump]
 
 ## log in to the portal
 

--- a/docs/alps/hardware.md
+++ b/docs/alps/hardware.md
@@ -1,4 +1,4 @@
-[](){#alps-hardware}
+[](){#ref-alps-hardware}
 # Alps Hardware
 
 Alps is a HPE Cray EX3000 system, a liquid cooled blade-based, high-density system.
@@ -47,27 +47,27 @@ There are currently four node types in Alps, with another becoming available in 
 | AMD MI250x     |   12   |   24  |     24      |  96         |
 | AMD MI300A     |   64   |  128  |    512      | 512         |
 
-[](){#gh200-node}
+[](){#ref-alps-gh200-node}
 ### NVIDIA GH200 GPU Nodes
 
 Perry Peak
 
-[](){#zen2-node}
+[](){#ref-alps-zen2-node}
 ### AMD Rome CPU Nodes
 
 EX425
 
-[](){#a100-node}
+[](){#ref-alps-a100-node}
 ### NVIDIA A100 GPU Nodes
 
 Grizzly Peak
 
-[](){#mi200-node}
+[](){#ref-alps-mi200-node}
 ### AMD MI250x GPU Nodes
 
 Bard Peak
 
-[](){#mi300-node}
+[](){#ref-alps-mi300-node}
 ### AMD MI300A GPU Nodes
 
 Parry Peak

--- a/docs/alps/index.md
+++ b/docs/alps/index.md
@@ -1,3 +1,4 @@
+[](){#ref-alps}
 # Alps Infrastructure
 
 Alps is a general-purpose compute and data Research Infrastructure (RI) open to the broad community of researchers in Switzerland and the rest of the world.
@@ -14,13 +15,13 @@ Additionally, network segregation ensures secure and isolated communication, wit
 
 -   :fontawesome-solid-signs-post: __Platforms__
 
-    [:octicons-arrow-right-24: Alps Platforms][platforms]
+    [:octicons-arrow-right-24: Alps Platforms][ref-alps-platforms]
 
 -   :fontawesome-solid-signs-post: __Clusters__
 
     The resources on Alps are partitioned and configured into versatile software defined clusters (vClusters).
 
-    [:octicons-arrow-right-24: Alps vClusters][clusters]
+    [:octicons-arrow-right-24: Alps vClusters][ref-alps-clusters]
 
 -   :fontawesome-solid-signs-post: __Hardware__
 

--- a/docs/alps/platforms.md
+++ b/docs/alps/platforms.md
@@ -1,28 +1,28 @@
-[](){#platforms}
+[](){#ref-alps-platforms}
 # Platforms on Alps
 
 A platform represents a set of scientific services along with compute and data resources hosted on the Alps research infrastructure, provided to a specific scientific community.
 Each platform addresses particular research needs and domains, such as climate and weather modeling, machine learning, or high-performance computing applications.
-A platform can consist of one or multiple [clusters][clusters], and its services can be managed either by CSCS or by the scientific community itself, including access control, usage policies, and support.
+A platform can consist of one or multiple [clusters][ref-alps-clusters], and its services can be managed either by CSCS or by the scientific community itself, including access control, usage policies, and support.
 
 <div class="grid cards" markdown>
 
 -   :fontawesome-solid-mountain: __Machine Learning Platform__
 
-    The Machine Learning Platform (MLp) hosts ML and AI researchers.
+    The Machine Learning Platform (MLP) hosts ML and AI researchers.
 
-    [:octicons-arrow-right-24: MLp][mlp]
+    [:octicons-arrow-right-24: MLP][ref-platform-mlp]
 
 -   :fontawesome-solid-mountain: __HPC Platform__
 
     !!! todo
 
-    [:octicons-arrow-right-24: HPCp][hpcp]
+    [:octicons-arrow-right-24: HPCP][ref-platform-hpcp]
 
 -   :fontawesome-solid-mountain: __Climate and Weather Platform__
 
     !!! todo
 
-    [:octicons-arrow-right-24: CWp][cwp]
+    [:octicons-arrow-right-24: CWP][ref-platform-cwp]
 
 </div>

--- a/docs/alps/storage.md
+++ b/docs/alps/storage.md
@@ -1,3 +1,4 @@
+[](){#ref-alps-storage}
 # Alps Storage
 
 !!! todo

--- a/docs/alps/vclusters.md
+++ b/docs/alps/vclusters.md
@@ -1,34 +1,42 @@
-[](){#clusters}
+[](){#ref-alps-clusters}
 # Alps Clusters
 
 A vCluster (versatile software-defined cluster) is a logical partition of the supercomputing resources where platform services are deployed. It serves as a dedicated environment supporting a specific platform. The composition of resources and services for each vCluster is defined in a configuration file used by an automated pipeline for deployment. Once deployed by CSCS, the vCluster becomes immutable.
 
 ## Clusters on Alps
 
-Clusters on Alps are provided as part of different [platforms][platforms].
+Clusters on Alps are provided as part of different [platforms][ref-alps-platforms].
 
 <div class="grid cards" markdown>
 -   :fontawesome-solid-mountain: __Machine Learning Platform__
 
     Clariden is the main Grace-Hopper cluster
 
-    [:octicons-arrow-right-24: Clariden][clariden]
+    [:octicons-arrow-right-24: Clariden][ref-cluster-clariden]
 
     Bristen is a small system with a100 nodes, used for **todo**
 
-    [:octicons-arrow-right-24: Bristen][bristen]
+    [:octicons-arrow-right-24: Bristen][ref-cluster-bristen]
 </div>
 
 <div class="grid cards" markdown>
--   :fontawesome-solid-mountain: __HPC Platform__ { .col-span-12 }
+-   :fontawesome-solid-mountain: __HPC Platform__
 
-    !!! todo
+    Daint is the main Grace-Hopper cluster for GPU workloads
+
+    [:octicons-arrow-right-24: Daint][ref-cluster-daint]
+
+    Eiger is a large AMD-CPU cluster for CPU workloads
+
+    [:octicons-arrow-right-24: Eiger][ref-cluster-eiger]
 </div>
 
 <div class="grid cards" markdown>
 -   :fontawesome-solid-mountain: __Climate and Weather Platform__
 
-    !!! todo
+    Santis is a Grace-Hopper cluster for climate and weather simulation
+
+    [:octicons-arrow-right-24: Santis][ref-cluster-santis]
 </div>
 
 

--- a/docs/build-install/uenv.md
+++ b/docs/build-install/uenv.md
@@ -2,7 +2,7 @@ Uenv are user environments that provide scientific applications, libraries and t
 
 For more documentation on how to find, download and use uenv in your workflow, see the [env tool documentation](../tools/uenv.md).
 
-[](){#building-uenv-spack}
+[](){#ref-building-uenv-spack}
 ## Building software using Spack
 
 Each uenv is tightly coupled with [Spack] and can be used as an upstream [Spack] instance, because

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,19 +8,19 @@ Start here to get access to CSCS services and Alps
 
     The first step is to get an account and a project
 
-    [:octicons-arrow-right-24: Accounts and Projects][account-management]
+    [:octicons-arrow-right-24: Accounts and Projects][ref-account-management]
 
 -   :fontawesome-solid-key: __Logging In__
 
     Once you have an account, you can set up multi factor authentification
 
-    [:octicons-arrow-right-24: Setting up MFA][mfa]
+    [:octicons-arrow-right-24: Setting up MFA][ref-mfa]
 
     Then access CSCS services
 
-    [:octicons-arrow-right-24: Accessing CSCS Web Services][access-web]
+    [:octicons-arrow-right-24: Accessing CSCS Web Services][ref-access-web]
 
-    [:octicons-arrow-right-24: Using SSH][access-ssh]
+    [:octicons-arrow-right-24: Using SSH][ref-ssh]
 
 </div>
 
@@ -32,15 +32,15 @@ The Alps Research infrastructure hosts multiple platforms and clusters targeting
 
     Once you have a project at CSCS, start here to find your platform:
 
-    [:octicons-arrow-right-24: Platforms overview][platforms]
+    [:octicons-arrow-right-24: Platforms overview][ref-alps-platforms]
 
     Go straight to the documentation for the platform that hosts your project:
 
-    [:octicons-arrow-right-24: HPC Platform][hpcp]
+    [:octicons-arrow-right-24: HPC Platform][ref-platform-hpcp]
 
-    [:octicons-arrow-right-24: Machine Learning Platform][mlp]
+    [:octicons-arrow-right-24: Machine Learning Platform][ref-platform-mlp]
 
-    [:octicons-arrow-right-24: Climate and Weather Platform][cwp]
+    [:octicons-arrow-right-24: Climate and Weather Platform][ref-platform-cwp]
 
 -   :fontawesome-solid-mountain-sun: __Alps__
 

--- a/docs/platforms/cwp/index.md
+++ b/docs/platforms/cwp/index.md
@@ -1,5 +1,5 @@
-[](){#cwp}
+[](){#ref-platform-cwp}
 # Climate and Weather Platform
 
 !!! todo
-    follow the template of the [MLp][mlp]
+    follow the template of the [MLp][ref-platform-mlp]

--- a/docs/platforms/hpcp/index.md
+++ b/docs/platforms/hpcp/index.md
@@ -1,5 +1,5 @@
-[](){#hpcp}
+[](){#ref-platform-hpcp}
 # HPC Platform
 
 !!! todo
-    follow the template of the [MLp][mlp]
+    follow the template of the [MLp][ref-platform-mlp]

--- a/docs/platforms/mlp/index.md
+++ b/docs/platforms/mlp/index.md
@@ -1,4 +1,4 @@
-[](){#mlp}
+[](){#ref-platform-mlp}
 # Machine Learning Platform
 
 !!! todo
@@ -13,24 +13,24 @@
 ### Getting access
 
 Project administrators (PIs and deputy PIs) of projects on the MLp can to invite users to join their project, before they can use the project's resources on Alps.
-This is performed using the [project management tool][waldur]
+This is performed using the [project management tool][ref-account-waldur]
 
-Once invited to a project, you will receive an email, which you can need to create an account and configure [multi-factor authentification][mfa] (MFA).
+Once invited to a project, you will receive an email, which you can need to create an account and configure [multi-factor authentification][ref-mfa] (MFA).
 
 ## vClusters
 
 The main cluster provided by the MLp is Clariden, a large Grace-Hopper GPU system on Alps.
 
 <div class="grid cards" markdown>
--   :fontawesome-solid-mountain: [__Clariden__][clariden]
+-   :fontawesome-solid-mountain: [__Clariden__][ref-cluster-clariden]
 
-    Clariden is the main [Grace-Hopper][gh200-node] cluster used for **todo**
+    Clariden is the main [Grace-Hopper][ref-alps-gh200-node] cluster used for **todo**
 </div>
 
 <div class="grid cards" markdown>
--   :fontawesome-solid-mountain: [__Bristen__][bristen]
+-   :fontawesome-solid-mountain: [__Bristen__][ref-cluster-bristen]
 
-    Bristen is a smaller system with [A100 GPU nodes][a100-node] for **todo**
+    Bristen is a smaller system with [A100 GPU nodes][ref-alps-a100-node] for **todo**
 </div>
 
 ## Guides and Tutorials

--- a/docs/policies/index.md
+++ b/docs/policies/index.md
@@ -22,7 +22,7 @@ Please note that the long term storage service is granted as long as your projec
 
 Furthermore, as soon as your project expires, the backup of the data belonging to the project will be disabled immediately: therefore no data backup will be available after the final data removal.
 
-[](){#policies-fair-use}
+[](){#ref-policies-fair-use}
 ## Fair Usage of Shared Resources
 
 The [Slurm][slurm] scheduling system is a shared resource that can handle a limited number of batch jobs and interactive commands simultaneously. Therefore users should not submit hundreds of Slurm jobs and commands at the same time, as doing so would infringe our fair usage policy.

--- a/docs/software/index.md
+++ b/docs/software/index.md
@@ -1,4 +1,4 @@
-[](){#software-overview}
+[](){#ref-software-overview}
 # Software
 
 CSCS provides a catalogue of software on Alps, include scientific applications, tools and programming environments.

--- a/docs/software/prgenv/index.md
+++ b/docs/software/prgenv/index.md
@@ -1,4 +1,4 @@
-[](){#prgenvs}
+[](){#ref-sofware-prgenvs}
 # Programming Environments
 
 !!! todo

--- a/docs/software/prgenv/linalg.md
+++ b/docs/software/prgenv/linalg.md
@@ -1,4 +1,4 @@
-[](){#uenv-linalg}
+[](){#ref-uenv-linalg}
 # linalg
 
 !!! todo

--- a/docs/software/prgenv/prgenv-gnu.md
+++ b/docs/software/prgenv/prgenv-gnu.md
@@ -1,4 +1,4 @@
-[](){#uenv-prgenv-gnu}
+[](){#ref-uenv-prgenv-gnu}
 # prgenv-gnu
 
 !!! todo

--- a/docs/software/prgenv/prgenv-nvfortran.md
+++ b/docs/software/prgenv/prgenv-nvfortran.md
@@ -1,4 +1,4 @@
-[](){#uenv-prgenv-nvfortran}
+[](){#ref-uenv-prgenv-nvfortran}
 # prgenv-nvfortran
 
 !!! todo

--- a/docs/software/sciapps/cp2k.md
+++ b/docs/software/sciapps/cp2k.md
@@ -1,4 +1,4 @@
-[](){#uenv-cp2k}
+[](){#ref-uenv-cp2k}
 # CP2K
 !!! todo
     complete docs

--- a/docs/software/sciapps/gromacs.md
+++ b/docs/software/sciapps/gromacs.md
@@ -1,4 +1,4 @@
-[](){#uenv-gromacs}
+[](){#ref-uenv-gromacs}
 # GROMACS
 !!! todo
     complete docs

--- a/docs/software/sciapps/index.md
+++ b/docs/software/sciapps/index.md
@@ -1,4 +1,4 @@
-[](){#sciapps}
+[](){#ref-software-sciapps}
 # Scientific Applications
 
 CSCS provides and supports a selection of scientific applications on the computing systems: we usually build community codes that are adopted by several users on our systems.
@@ -7,12 +7,12 @@ Please have a look at the individual application page on the menu to find out ho
 
 CSCS staff can also help users with performance analysis to optimise their workflow in production.
 
-* [CP2K][uenv-cp2k]
-* [GROMACS][uenv-gromacs]
-* [LAMMPS][uenv-lammps]
-* [NAMD][uenv-namd]
-* [Quantum ESPRESSO][uenv-quantumespresso]
-* [VASP][uenv-vasp]
+* [CP2K][ref-uenv-cp2k]
+* [GROMACS][ref-uenv-gromacs]
+* [LAMMPS][ref-uenv-lammps]
+* [NAMD][ref-uenv-namd]
+* [Quantum ESPRESSO][ref-uenv-quantumespresso]
+* [VASP][ref-uenv-vasp]
 
 !!! warning "Unsupported Applications"
     Please note that Amber and CPMD previously provided on the Piz Daint XC system are not provided by CSCS on Alps.

--- a/docs/software/sciapps/lammps.md
+++ b/docs/software/sciapps/lammps.md
@@ -1,4 +1,4 @@
-[](){#uenv-lammps}
+[](){#ref-uenv-lammps}
 # LAMMPS
 !!! todo
     complete docs

--- a/docs/software/sciapps/namd.md
+++ b/docs/software/sciapps/namd.md
@@ -1,4 +1,4 @@
-[](){#uenv-namd}
+[](){#ref-uenv-namd}
 # NAMD
 
 [NAMD] is a parallel molecular dynamics code based on [Charm++], designed for high-performance simulations of large biomolecular systems.

--- a/docs/software/sciapps/quantumespresso.md
+++ b/docs/software/sciapps/quantumespresso.md
@@ -1,4 +1,4 @@
-[](){#uenv-quantumespresso}
+[](){#ref-uenv-quantumespresso}
 # Quantum ESPRESSO
 !!! todo
     complete docs

--- a/docs/software/sciapps/vasp.md
+++ b/docs/software/sciapps/vasp.md
@@ -1,4 +1,4 @@
-[](){#uenv-vasp}
+[](){#ref-uenv-vasp}
 # VASP
 
 !!! todo

--- a/docs/software/tools/index.md
+++ b/docs/software/tools/index.md
@@ -1,4 +1,4 @@
-[](){#tools}
+[](){#ref-software-tools}
 # Tools Software
 
 !!! todo

--- a/docs/software/tools/linaro.md
+++ b/docs/software/tools/linaro.md
@@ -1,4 +1,4 @@
-[](){#uenv-linaro}
+[](){#ref-uenv-linaro}
 # Linaro Forge
 
 [Linaro Forge](https://www.linaroforge.com/downloadForge) is a suite of profiling and debugging tools.
@@ -159,7 +159,7 @@ Some notes on the examples above:
 * SSH Forwarding via `ela.cscs.ch` is used to access the cluster.
 * replace the username `cscsusername` with your CSCS user name that you would normally use to open an SSH connection to CSCS.
 * `Remote Installation Path` is pointing to the install directotory of ddt inside the image
-* private keys should be the ones generated for CSCS MFA, and this field does not need to be set if you have added the key to your [SSH agent][ssh-ssh-agent].
+* private keys should be the ones generated for CSCS MFA, and this field does not need to be set if you have added the key to your [SSH agent][ref-ssh-agent].
 
 Once configured, test and save the configuration:
 

--- a/docs/tools/slurm.md
+++ b/docs/tools/slurm.md
@@ -1,4 +1,4 @@
-[](){#slurm}
+[](){#ref-slurm}
 # SLURM
 
 CSCS uses the [SLURM](https://slurm.schedmd.com/documentation.html) as its workload manager to efficiently schedule and manage jobs on Alps vClusters.
@@ -17,16 +17,16 @@ Each type of node has different resource constraints and capabilities, which SLU
 
 The following sections will provide detailed guidance on how to use SLURM to request and manage CPU cores, memory, and GPUs in jobs. These instructions will help users optimize their workload execution and ensure efficient use of CSCS computing resources.
 
-[](){#gh200-slurm}
+[](){#ref-slurm-gh200}
 ### NVIDIA GH200 GPU Nodes
 
-The [GH200 nodes on Alps][gh200-node] have four GPUs per node, and SLURM job submissions must be configured appropriately to best make use of the resources.
+The [GH200 nodes on Alps][ref-alps-gh200-node] have four GPUs per node, and SLURM job submissions must be configured appropriately to best make use of the resources.
 Applications that can saturate the GPUs with a single process per GPU should generally prefer this mode.
-[Configuring SLURM jobs to use a single GPU per rank][gh200-slurm-single-rank-per-gpu] is also the most straightforward setup.
+[Configuring SLURM jobs to use a single GPU per rank][ref-slurm-gh200-single-rank-per-gpu] is also the most straightforward setup.
 Some applications perform badly with a single rank per GPU, and require use of [NVIDIA's Multi-Process Service (MPS)] to oversubscribe GPUs with multiple ranks per GPU.
 
 The best SLURM configuration is application- and workload-specific, so it is worth testing which works best in your particular case.
-See [Scientific Applications][sciapps] for information about recommended application-specific SLURM configurations.
+See [Scientific Applications][ref-software-sciapps] for information about recommended application-specific SLURM configurations.
 
 !!! warning
     The GH200 nodes have their GPUs configured in ["default" compute mode](https://docs.nvidia.com/deploy/mps/index.html#gpu-compute-modes).
@@ -34,12 +34,12 @@ See [Scientific Applications][sciapps] for information about recommended applica
     Unlike "exclusive process" mode, "default" mode allows multiple processes to submit work to a single GPU simultaneously.
     This also means that different ranks on the same node can inadvertently use the same GPU leading to suboptimal performance or unused GPUs, rather than job failures.
     
-    Some applications benefit from using multiple ranks per GPU. However, [MPS should be used][gh200-slurm-multi-rank-per-gpu] in these cases.
+    Some applications benefit from using multiple ranks per GPU. However, [MPS should be used][ref-slurm-gh200-multi-rank-per-gpu] in these cases.
     
     If you are unsure about which GPU is being used for a particular rank, print the `CUDA_VISIBLE_DEVICES` variable, along with e.g. `SLURM_LOCALID`, `SLURM_PROCID`, and `SLURM_NODEID` variables, in your job script.
     If the variable is unset or empty all GPUs are visible to the rank and the rank will in most cases only use the first GPU. 
 
-[](){#gh200-slurm-single-rank-per-gpu}
+[](){#ref-slurm-gh200-single-rank-per-gpu}
 #### One rank per GPU
 
 Configuring SLURM to use one GH200 GPU per rank is easiest done using the `--ntasks-per-node=4` and `--gpus-per-task=1` SLURM flags.
@@ -58,7 +58,7 @@ srun <application>
     
 Omitting the `--gpus-per-task` results in `CUDA_VISIBLE_DEVICES` being unset, which will lead to most applications using the first GPU on all ranks.
 
-[](){#gh200-slurm-multi-rank-per-gpu}
+[](){#ref-slurm-gh200-multi-rank-per-gpu}
 #### Multiple ranks per GPU
 
 Using multiple ranks per GPU can improve performance e.g. of applications that don't generate enough work for a GPU using a single rank, or ones that scale badly to all 72 cores of the Grace CPU.
@@ -122,7 +122,7 @@ The configuration that is optimal for your application may be different.
 
 [NVIDIA's Multi-Process Service (MPS)]: https://docs.nvidia.com/deploy/mps/index.html
 
-[](){#amdcpu-slurm}
+[](){#ref-slurm-amdcpu}
 ## AMD CPU
 
 !!! todo

--- a/docs/tools/uenv.md
+++ b/docs/tools/uenv.md
@@ -1,4 +1,4 @@
-[](){#uenv}
+[](){#ref-tool-uenv}
 # uenv
 
 Uenv are user environments that provide scientific applications, libraries and tools.
@@ -51,7 +51,7 @@ Used to differentiate between _releases_ of a versioned uenv. Some examples of t
 
 The name of the Alps cluster for which the uenv was built.
 
-[](){#uenv-label-uarch}
+[](){#ref-tool-uenv-label-uarch}
 #### `uarch`
 
 The node type (microarchitecture) that the uenv is built for:
@@ -211,7 +211,7 @@ To be able to pull such images, you first need to configure the token for that s
 !!! note
     As of March 2025, the only restricted software is VASP.
 
-[](){#uenv-start}
+[](){#ref-tool-uenv-start}
 ## Starting a uenv session
 
 The `uenv start` command will start a new shell with one or more uenv images mounted.
@@ -380,9 +380,9 @@ By default, the modules are not activated when a uenv is started, and need to be
 
 uenv images provide a full upstream Spack configuration to facilitate building your own software with Spack using the packages installed inside as dependencies.
 No view needs to be loaded to use Spack, however all uenv provide a `spack` view that sets some environment variables that contain useful information like the location of the Spack configuration, and the version of Spack that was used to build the uenv.
-For more information, see our guide on building software with [Spack and uenv][building-uenv-spack].
+For more information, see our guide on building software with [Spack and uenv][ref-building-uenv-spack].
 
-[](){#uenv-run}
+[](){#ref-tool-uenv-run}
 ## Running a uenv
 
 The `uenv run` command can be used to run an application or script in a uenv environment, and return control to the calling shell when the command has finished running.
@@ -439,7 +439,7 @@ The command takes two arguments:
     * `name` is the name, e.g. `prgenv-gnu`, `gromacs`, `vistools`.
     * `version` is a version string, e.g. `24.11`, `v1.2`, `2025-rc2`
     * `system` is the CSCS cluster to build on (e.g. `daint`, `santis`, `clariden`, `eiger`)
-    * `uarch` is the [micro-architecture][uenv-label-uarch].
+    * `uarch` is the [micro-architecture][ref-tool-uenv-label-uarch].
 
 !!! example "building a uenv"
     Call the 
@@ -471,7 +471,7 @@ This makes it easy to share your uenv with other users, by giving them the name,
     uenv image find service::@daint
     ```
 
-[](){#uenv-slurm}
+[](){#ref-tool-uenv-slurm}
 ## SLURM integration
 
 The environment to load can be provided directly to SLURM via three arguments:
@@ -548,7 +548,7 @@ it is possible to override the default uenv by passing a different `--uenv`  and
 
 * Note how the second call has access to `mpicc`, provided by `prgenv-gnu`.
 
-[](){#uenv-installation}
+[](){#ref-tool-uenv-installation}
 ## Installing the uenv tool
 
 The command line tool can be installed from source, if you are working on a cluster that does not have uenv installed, or if you need to test a new version.

--- a/docs/vclusters/bristen.md
+++ b/docs/vclusters/bristen.md
@@ -1,4 +1,4 @@
-[](){bristen}
+[](){#ref-cluster-bristen}
 # Bristen
 
 !!! todo

--- a/docs/vclusters/clariden.md
+++ b/docs/vclusters/clariden.md
@@ -1,4 +1,4 @@
-[](){clariden}
+[](){#ref-cluster-clariden}
 # Clariden
 
 !!! todo
@@ -36,7 +36,7 @@
 
 Clariden uses [SLURM][slurm] as the workload manager, which is used to launch and monitor distributed workloads, such as training runs.
 
-See detailed instructions on how to run jobs on the [Grace-Hopper nodes][gh200-slurm].
+See detailed instructions on how to run jobs on the [Grace-Hopper nodes][ref-slurm-gh200].
 
 ## Storage
 
@@ -47,7 +47,7 @@ See detailed instructions on how to run jobs on the [Grace-Hopper nodes][gh200-s
 
     Refer to the specific file systems that these map onto (capstor, iopstor, waldur), and link to the storage docs for these.
 
-    Also discuss any specific storage policies. You might want to discuss storage policies for MLp one level up, in the [MLp docs][mlp].
+    Also discuss any specific storage policies. You might want to discuss storage policies for MLp one level up, in the [MLp docs][ref-platform-mlp].
 
 * attached storage and policies
 

--- a/docs/vclusters/daint.md
+++ b/docs/vclusters/daint.md
@@ -1,0 +1,2 @@
+[](){#ref-cluster-daint}
+# Daint

--- a/docs/vclusters/eiger.md
+++ b/docs/vclusters/eiger.md
@@ -1,0 +1,3 @@
+[](){#ref-cluster-eiger}
+# Eiger
+

--- a/docs/vclusters/santis.md
+++ b/docs/vclusters/santis.md
@@ -1,0 +1,3 @@
+[](){#ref-cluster-santis}
+# Santis
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,8 +37,11 @@ nav:
     - 'bristen': vclusters/bristen.md
   - 'HPC Platform':
     - platforms/hpcp/index.md
+    - 'daint': vclusters/daint.md
+    - 'eiger': vclusters/eiger.md
   - 'Climate and Weather Platform':
     - platforms/cwp/index.md
+    - 'santis': vclusters/santis.md
   - 'Software':
     - software/index.md
     - 'Scientific Applications':


### PR DESCRIPTION
Convert all internal links to use the `ref-$name` pattern, to improve robustness of internal linking.