### PR TITLE
Add internet access page

### DIFF
--- a/docs/alps/hardware.md
+++ b/docs/alps/hardware.md
@@ -21,6 +21,7 @@ This approach to cooling provides greater efficiency for the rack-level cooling,
 * Maximum of 64 quad-blade compute blades
 * Maximum of 64 Slingshot switch blades
 
+[](){#ref-alps-hsn}
 ## Alps High Speed Network
 
 !!! todo

--- a/docs/guides/internet-access.md
+++ b/docs/guides/internet-access.md
@@ -9,12 +9,12 @@ Login nodes have public IP addresses which means that they can directly access t
     Compute nodes are configured with the following environment variables to use the proxy server:
     
     ```bash
-    https_proxy=http://proxy.cscs.ch:8080
-    http_proxy=http://proxy.cscs.ch:8080
-    no_proxy=.local, .cscs.ch, localhost, 148.187.0.0/16, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
-    HTTPS_PROXY=http://proxy.cscs.ch:8080
-    HTTP_PROXY=http://proxy.cscs.ch:8080
-    NO_PROXY=.local, .cscs.ch, localhost, 148.187.0.0/16, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+    export https_proxy=http://proxy.cscs.ch:8080
+    export http_proxy=http://proxy.cscs.ch:8080
+    export no_proxy=.local, .cscs.ch, localhost, 148.187.0.0/16, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+    export HTTPS_PROXY=http://proxy.cscs.ch:8080
+    export HTTP_PROXY=http://proxy.cscs.ch:8080
+    export NO_PROXY=.local, .cscs.ch, localhost, 148.187.0.0/16, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
     ```
 
 !!! warning "Public IPs are a shared resource"

--- a/docs/guides/internet-access.md
+++ b/docs/guides/internet-access.md
@@ -37,7 +37,7 @@ Match Host *,!148.187.0.0/16,!192.168.0.0/16,!172.16.0.0/12,!10.0.0.0/8exec "hos
 
 This configuration takes into account that login and compute nodes require a different setup.
 
-??? info "Error message when cloning without the proxy set up for SSH"
+??? warning "Error message when cloning without the proxy set up for SSH"
     When cloning a git repository without the correct SSH configuration, cloning will time out as follows:
     ```bash
     [daint][<user>@daint-ln001 ~]$ git clone git@github.com:open-mpi/ompi.git

--- a/docs/guides/internet-access.md
+++ b/docs/guides/internet-access.md
@@ -17,9 +17,16 @@ Login nodes have public IP addresses which means that they can directly access t
     NO_PROXY=.local, .cscs.ch, localhost, 148.187.0.0/16, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
     ```
 
+!!! warning "Public IPs are a shared resource"
+    Be aware that public IPs, whether on login nodes or through the proxy, are essentially a shared resource.
+    Many services will rate limit or block usage based on the IP address if abused.
+    An example is pulling container images from Docker Hub.
+    [Authenticating with Docker Hub][ref-ce-third-party-private-registries] makes their rate limit apply per user instead.
+
 ## Using SSH through the proxy server 
 
-While use of the proxy server is transparent for most use cases, e.g. cloning git repositories from GitHub over SSH requires additional configuration for compute nodes.
+While use of the proxy server is transparent for most use cases, others need additional configuration for compute nodes.
+An example is cloning git repositories from GitHub over SSH.
 Cloning over https works without additional configuration.
 To make SSH use the proxy server, add the following to your `~/.ssh/config` file:
 
@@ -30,7 +37,7 @@ Match Host *,!148.187.0.0/16,!192.168.0.0/16,!172.16.0.0/12,!10.0.0.0/8 exec "ho
 
 This configuration takes into account that login and compute nodes require a different setup.
 
-!!! info "Error message when cloning without the proxy set up for SSH"
+??? info "Error message when cloning without the proxy set up for SSH"
     When cloning a git repository without the correct SSH configuration, cloning will time out as follows:
     ```bash
     [daint][<user>@daint-ln001 ~]$ git clone git@github.com:open-mpi/ompi.git

--- a/docs/guides/internet-access.md
+++ b/docs/guides/internet-access.md
@@ -30,8 +30,8 @@ An example is cloning git repositories from GitHub over SSH.
 Cloning over https works without additional configuration.
 To make SSH use the proxy server, add the following to your `~/.ssh/config` file:
 
-```bash
-Match Host *,!148.187.0.0/16,!192.168.0.0/16,!172.16.0.0/12,!10.0.0.0/8 exec "hostname -I | grep -vqF 148.187."
+``` title="~/.ssh/config"
+Match Host *,!148.187.0.0/16,!192.168.0.0/16,!172.16.0.0/12,!10.0.0.0/8exec "hostname -I | grep -vqF 148.187."
     ProxyCommand nc -X connect -x proxy.cscs.ch:8080 %h %p
 ```
 

--- a/docs/software/container-engine.md
+++ b/docs/software/container-engine.md
@@ -268,9 +268,15 @@ image = "/capstor/scratch/cscs/<username>/nvidia+cuda+11.8.0-cudnn8-devel-ubuntu
 !!! note
     It is recommended to save images in `/capstor/scratch/cscs/<username>` or its subdirectories before using them with the CE.
 
+[](){#ref-ce-third-party-private-registries}
 ### Third-party and private registries
 
 [Docker Hub](https://hub.docker.com/) is the default registry from which remote images are imported.
+
+!!! warning "Registry rate limits"
+    Some registries will rate limit image pulls by IP address.
+    Since [public IPs are a shared resource][ref-guides-internet-access] we recommend authenticating even for publicly available images.
+    For example, [Docker Hub applies its rate limits per user when authenticated](https://docs.docker.com/docker-hub/usage/).
 
 To use an image from a different registry, the corresponding registry URL has to be prepended to the image reference, using a hash character (#) as a separator. For example:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
     - 'Object Storage': storage/object.md
   - 'Guides':
     - guides/index.md
+    - 'Internet Access on Alps': guides/internet-access.md
     - 'Storage': guides/storage.md
   - 'Policies':
     - policies/index.md


### PR DESCRIPTION
Ports https://confluence.cscs.ch/spaces/KB/pages/868820917/Internet+access+on+the+Alps+infrastructure to the new docs. Currently under "Guides".

@bcumming do you think it makes sense to rename "Guides" already now or shall we keep it like this for now.

This section could fit close to the "Alps High Speed Network" section, but I think it's a bit too hidden to put it there. Additionally, I think it's good if the hardware is focused on the hardware itself and doesn't go into implementation details like this (i.e. that a proxy server is required for compute nodes).