### PR TITLE
Start "Communication Libraries" section

### DIFF
--- a/docs/alps/hardware.md
+++ b/docs/alps/hardware.md
@@ -21,6 +21,7 @@ This approach to cooling provides greater efficiency for the rack-level cooling,
 * Maximum of 64 quad-blade compute blades
 * Maximum of 64 Slingshot switch blades
 
+[](){#ref-alps-hsn}
 ## Alps High Speed Network
 
 !!! todo

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,6 +65,7 @@ The Alps Research infrastructure hosts multiple platforms and clusters targeting
 
 </div>
 
+[](){#ref-get-in-touch}
 ## Get in Touch
 
 If you can't find the information that you need in the documentation, help is available.

--- a/docs/software/communication/cray-mpich.md
+++ b/docs/software/communication/cray-mpich.md
@@ -10,7 +10,12 @@ On this page we outline the most common workflows and issues that you may encoun
 ## GPU-aware MPI
 
 We recommend using GPU-aware MPI whenever possible, as it almost always provides a significant performance improvement compared to communication through CPU memory.
-To use GPU-aware MPI with Cray MPICH, 1. the application must be linked to the GTL library, and 2. the `MPICH_GPU_SUPPORT_ENABLED=1` environment variable must be set. If either of these are missing, the application will fail to communicate GPU buffers.
+To use GPU-aware MPI with Cray MPICH
+
+1. the application must be linked to the GTL library, and
+2. the `MPICH_GPU_SUPPORT_ENABLED=1` environment variable must be set.
+
+If either of these are missing, the application will fail to communicate GPU buffers.
 
 In supported uenvs, Cray MPICH is built with GPU support (on clusters that have GPUs).
 This means that Cray MPICH will automatically be linked to the GTL library, which implements the the GPU support for Cray MPICH.

--- a/docs/software/communication/cray-mpich.md
+++ b/docs/software/communication/cray-mpich.md
@@ -116,5 +116,5 @@ or
 Assertion failed [...]: MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX.count == 0
 ```
 
-??? Workaround
+??? info "Workaround"
     The issue can be worked around by falling back to a less optimized implementation of `MPICH_THREAD_MULTIPLE` by setting `MPICH_OPT_THREAD_SYNC=0`.

--- a/docs/software/communication/cray-mpich.md
+++ b/docs/software/communication/cray-mpich.md
@@ -22,7 +22,7 @@ This means that Cray MPICH will automatically be linked to the GTL library, whic
 
 ??? info "Checking that the application links to the GTL library"
 
-    To check if your application is linked against the required GTL library, running `ldd` on your executable `myexecutable` on your executable should print something similar to:
+    To check if your application is linked against the required GTL library, running `ldd` on your executable `myexecutable` should print something similar to:
     ```bash
     $ ldd myexecutable | grep gtl
             libmpi_gtl_cuda.so => /user-environment/linux-sles15-neoverse_v2/gcc-13.2.0/cray-gtl-8.1.30-fptqzc5u6t4nals5mivl75nws2fb5vcq/lib/libmpi_gtl_cuda.so (0x0000ffff82aa0000)

--- a/docs/software/communication/cray-mpich.md
+++ b/docs/software/communication/cray-mpich.md
@@ -17,9 +17,11 @@ This means that Cray MPICH will automatically be linked to the GTL library, whic
 
 ??? info "Checking that the application links to the GTL library"
 
-    To check if your application is linked against the required GTL library, running `ldd`` on your executable should print something similar to:
+    To check if your application is linked against the required GTL library, running `ldd` on your executable `myexecutable` on your executable should print something similar to:
+    ```bash
     $ ldd myexecutable | grep gtl
             libmpi_gtl_cuda.so => /user-environment/linux-sles15-neoverse_v2/gcc-13.2.0/cray-gtl-8.1.30-fptqzc5u6t4nals5mivl75nws2fb5vcq/lib/libmpi_gtl_cuda.so (0x0000ffff82aa0000)
+    ```
     
     The path may be different, but the `libmpi_gtl_cuda.so` library should be printed when using CUDA.
     In ROCm environments the `libmpi_gtl_hsa.so` library should be linked.

--- a/docs/software/communication/cray-mpich.md
+++ b/docs/software/communication/cray-mpich.md
@@ -1,0 +1,114 @@
+[](){#ref-communication-cray-mpich}
+# Cray MPICH
+
+Cray MPICH is the recommended MPI implementation on Alps.
+It is available through uenvs like [prgenv-gnu][ref-uenv-prgenv-gnu] and [the application-specific uenvs][ref-software-sciapps].
+
+The [Cray MPICH documentation](https://cpe.ext.hpe.com/docs/latest/mpt/mpich/index.html) contains detailed information about Cray MPICH.
+On this page we outline the most common workflows and issues that you may encounter on Alps.
+
+## GPU-aware MPI
+
+We recommend using GPU-aware MPI whenever possible, as it almost always provides a significant performance improvement compared to communication through CPU memory.
+To use GPU-aware MPI with Cray MPICH, 1. the application must be linked to the GTL library, and 2. the `MPICH_GPU_SUPPORT_ENABLED=1` environment variable must be set. If either of these are missing, the application will fail to communicate GPU buffers.
+
+In supported uenvs, Cray MPICH is built with GPU support (on clusters that have GPUs).
+This means that Cray MPICH will automatically be linked to the GTL library, which implements the the GPU support for Cray MPICH.
+
+??? info "Checking that the application links to the GTL library"
+
+    To check if your application is linked against the required GTL library, running `ldd`` on your executable should print something similar to:
+    $ ldd myexecutable | grep gtl
+            libmpi_gtl_cuda.so => /user-environment/linux-sles15-neoverse_v2/gcc-13.2.0/cray-gtl-8.1.30-fptqzc5u6t4nals5mivl75nws2fb5vcq/lib/libmpi_gtl_cuda.so (0x0000ffff82aa0000)
+    
+    The path may be different, but the `libmpi_gtl_cuda.so` library should be printed when using CUDA.
+    In ROCm environments the `libmpi_gtl_hsa.so` library should be linked.
+    If the GTL library is not linked, nothing will be printed.
+
+In addition to linking to the GTL library, Cray MPICH must be configured to be GPU-aware at runtime by setting the `MPICH_GPU_SUPPORT_ENABLED=1` environment variable.
+On some CSCS systems this option is set by default.
+See [this page][ref-slurm-gh200] for more information on configuring SLURM to use GPUs.
+
+!!! warning "Segmentation faults when trying to communicate GPU buffers without `MPICH_GPU_SUPPORT_ENABLED=1`"
+    If you attempt to communicate GPU buffers through MPI without setting `MPICH_GPU_SUPPORT_ENABLED=1`, it will lead to segmentation faults, usually without any specific indication that it is the communication that fails.
+    Make sure that the option is set if you are communicating GPU buffers through MPI.
+    
+!!! warning "Error: "`GPU_SUPPORT_ENABLED` is requested, but GTL library is not linked""
+    If `MPICH_GPU_SUPPORT_ENABLED` is set to `1` and your application does not link against one of the GTL libraries you will get an error similar to the following during MPI initialization:
+    ```bash
+    MPICH ERROR [Rank 0] [job id 410301.1] [Thu Feb 13 12:42:18 2025] [nid005414] - Abort(-1) (rank 0 in comm 0): MPIDI_CRAY_init: GPU_SUPPORT_ENABLED is requested, but GTL library is not linked
+     (Other MPI error)
+
+    aborting job:
+    MPIDI_CRAY_init: GPU_SUPPORT_ENABLED is requested, but GTL library is not linked
+    ```
+
+    This means that the required GTL library was not linked to the application.
+    In supported uenvs, GPU support is enabled by default.
+    If you believe a uenv should have GPU support but you are getting the above error, feel free to [get in touch with us][ref-get-in-touch] to understand whether there is an issue with the uenv or something else in your environment. 
+    If you are using Cray modules you must load the corresponding accelerator module, e.g. `craype-accel-nvidia90`, before compiling your application.
+
+    Alternatively, if you wish to not use GPU-aware MPI, either unset `MPICH_GPU_SUPPORT_ENABLED` or explicitly set it to `0` in your launch scripts.
+
+## Known issues
+
+This section documents known issues related to Cray MPICH on Alps. Resolved issues are also listed for reference.
+
+### Existing Issues
+
+#### Cray MPICH hangs
+
+Cray MPICH may sometimes hang on larger runs.
+
+!!! info "Workaround"
+
+    There are many possible reasons why an application would hang, many unrelated to Cray MPICH. However, if you are experiencing hangs the issue may be worked around by setting:
+    ```bash
+    export FI_MR_CACHE_MONITOR=disabled
+    ```
+
+Performance may be negatively affected by this option.
+
+### Resolved issues
+
+#### `"cxil_map: write error"` when doing inter-node GPU-aware MPI communication
+
+!!! info
+    The issue has been resolved by a system update on 7th October 2024 and the workaround is no longer needed.
+    The issue was caused by a system misconfiguration.
+
+When doing inter-node GPU-aware communication with Cray MPICH after the October 2024 update on Alps, applications will fail with:
+```bash
+cxil_map: write error
+```
+
+??? Workaround
+    The only workaround is to not use inter-node GPU-aware MPI.
+
+    For users of CP2K encountering this issue, one can disable the use of COSMA, which uses GPU-aware MPI, by placing the following in the `&GLOBAL`` section of your input file: 
+    ```bash
+    &FM
+    TYPE_OF_MATRIX_MULTIPLICATION SCALAPACK
+    &END FM
+    ```
+
+    Unless you run RPA calculations, this should have limited impact on performance.
+
+#### `MPI_THREAD_MULTIPLE` does not work
+
+!!! info
+    The issue has been resolved in Cray MPICH version 8.1.30.
+
+When using `MPI_THREAD_MULTIPLE` on GH200 systems Cray MPICH may fail with an assertion that looks similar to:
+```bash
+Assertion failed [...]: (&MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX)->count == 0
+```
+
+or
+
+```bash
+Assertion failed [...]: MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX.count == 0
+```
+
+??? Workaround
+    The issue can be worked around by falling back to a less optimized implementation of `MPICH_THREAD_MULTIPLE` by setting `MPICH_OPT_THREAD_SYNC=0`.

--- a/docs/software/communication/cray-mpich.md
+++ b/docs/software/communication/cray-mpich.md
@@ -80,7 +80,7 @@ Performance may be negatively affected by this option.
 
 #### `"cxil_map: write error"` when doing inter-node GPU-aware MPI communication
 
-??? info "Issue resolved on the 7th of October 2024"
+??? info "The issue has been resolved on the 7th of October 2024 with a system update"
     The issue was caused by a system misconfiguration.
 
 When doing inter-node GPU-aware communication with Cray MPICH after the update on the 30th of September 2024 on Alps, applications will fail with:
@@ -91,14 +91,15 @@ cxil_map: write error
 ??? info "Workaround"
     The only workaround is to not use inter-node GPU-aware MPI.
 
-    For users of CP2K encountering this issue, one can disable the use of COSMA, which uses GPU-aware MPI, by placing the following in the `&GLOBAL`` section of your input file: 
-    ```bash
-    &FM
-    TYPE_OF_MATRIX_MULTIPLICATION SCALAPACK
-    &END FM
-    ```
+    ??? tip "Workaround for CP2K"
+        For users of CP2K encountering this issue, one can disable the use of COSMA, which uses GPU-aware MPI, by placing the following in the `&GLOBAL` section of your input file: 
+        ```bash
+        &FM
+        TYPE_OF_MATRIX_MULTIPLICATION SCALAPACK
+        &END FM
+        ```
 
-    Unless you run RPA calculations, this should have limited impact on performance.
+        Unless you run RPA calculations, this should have limited impact on performance.
 
 #### `MPI_THREAD_MULTIPLE` does not work
 

--- a/docs/software/communication/cray-mpich.md
+++ b/docs/software/communication/cray-mpich.md
@@ -80,16 +80,15 @@ Performance may be negatively affected by this option.
 
 #### `"cxil_map: write error"` when doing inter-node GPU-aware MPI communication
 
-!!! info
-    The issue has been resolved by a system update on 7th October 2024 and the workaround is no longer needed.
+??? info "Issue resolved on the 7th of October 2024"
     The issue was caused by a system misconfiguration.
 
-When doing inter-node GPU-aware communication with Cray MPICH after the October 2024 update on Alps, applications will fail with:
+When doing inter-node GPU-aware communication with Cray MPICH after the update on the 30th of September 2024 on Alps, applications will fail with:
 ```bash
 cxil_map: write error
 ```
 
-??? Workaround
+??? info "Workaround"
     The only workaround is to not use inter-node GPU-aware MPI.
 
     For users of CP2K encountering this issue, one can disable the use of COSMA, which uses GPU-aware MPI, by placing the following in the `&GLOBAL`` section of your input file: 
@@ -103,8 +102,7 @@ cxil_map: write error
 
 #### `MPI_THREAD_MULTIPLE` does not work
 
-!!! info
-    The issue has been resolved in Cray MPICH version 8.1.30.
+!!! info "The issue has been resolved in Cray MPICH version 8.1.30"
 
 When using `MPI_THREAD_MULTIPLE` on GH200 systems Cray MPICH may fail with an assertion that looks similar to:
 ```bash

--- a/docs/software/communication/index.md
+++ b/docs/software/communication/index.md
@@ -4,8 +4,10 @@
 CSCS provides common communication libraries optimized for the [Slingshot 11 network on Alps][ref-alps-hsn].
 
 For most scientific applications relying on MPI, [Cray MPICH][ref-communication-cray-mpich] is recommended.
+[OpenMPI][ref-communication-openmpi] may also be used, with limitations.
+Both Cray MPICH and OpenMPI make use of [libfabric][ref-communication-libfabric] to interact with the underlying network.
 
-Most machine learning applications rely on [NCCL][ref-communication-nccl] for high-performance implementations of collectives.
+Most machine learning applications rely on [NCCL][ref-communication-nccl] or [RCCL][ref-communication-rccl] for high-performance implementations of collectives.
 NCCL has to be configured with a plugin using [libfabric][ref-communication-libfabric] to make full use of the Slingshot network.
 
 See the individual pages for each library for information on how to use and best configure the libraries.

--- a/docs/software/communication/index.md
+++ b/docs/software/communication/index.md
@@ -8,7 +8,7 @@ For most scientific applications relying on MPI, [Cray MPICH][ref-communication-
 Both Cray MPICH and OpenMPI make use of [libfabric][ref-communication-libfabric] to interact with the underlying network.
 
 Most machine learning applications rely on [NCCL][ref-communication-nccl] or [RCCL][ref-communication-rccl] for high-performance implementations of collectives.
-NCCL has to be configured with a plugin using [libfabric][ref-communication-libfabric] to make full use of the Slingshot network.
+NCCL and RCCL have to be configured with a plugin using [libfabric][ref-communication-libfabric] to make full use of the Slingshot network.
 
 See the individual pages for each library for information on how to use and best configure the libraries.
 

--- a/docs/software/communication/index.md
+++ b/docs/software/communication/index.md
@@ -1,0 +1,17 @@
+[](){#ref-software-communication}
+# Communication Libraries
+
+CSCS provides common communication libraries optimized for the [Slingshot 11 network on Alps][ref-alps-hsn].
+
+For most scientific applications relying on MPI, [Cray MPICH][ref-communication-cray-mpich] is recommended.
+
+Most machine learning applications rely on [NCCL][ref-communication-nccl] for high-performance implementations of collectives.
+NCCL has to be configured with a plugin using [libfabric][ref-communication-libfabric] to make full use of the Slingshot network.
+
+See the individual pages for each library for information on how to use and best configure the libraries.
+
+* [Cray MPICH][ref-communication-cray-mpich]
+* [OpenMPI][ref-communication-openmpi]
+* [NCCL][ref-communication-nccl]
+* [RCCL][ref-communication-rccl]
+* [libfabric][ref-communication-libfabric]

--- a/docs/software/communication/libfabric.md
+++ b/docs/software/communication/libfabric.md
@@ -1,0 +1,7 @@
+[](){#ref-communication-libfabric}
+# Libfabric
+
+[Libfabric](https://ofiwg.github.io/libfabric/), or Open Fabrics Interfaces (OFI), is a low level networking library that abstracts away various networking backends.
+It is used by Cray MPICH, and can be used together with OpenMPI, NCCL, and RCCL to make use of the [Slingshot network on Alps][ref-alps-hsn].
+
+!!! todo

--- a/docs/software/communication/nccl.md
+++ b/docs/software/communication/nccl.md
@@ -1,0 +1,10 @@
+[](){#ref-communication-nccl}
+# NCCL
+
+[NCCL](https://developer.nvidia.com/nccl) is an optimized inter-GPU communication library for NVIDIA GPUs.
+It is commonly used in machine learning frameworks, but traditional scientific applications can also benefit from NCCL.
+
+!!! todo
+    - high level description
+    - libfabric/aws-ofi-nccl plugin
+    - configuration options

--- a/docs/software/communication/openmpi.md
+++ b/docs/software/communication/openmpi.md
@@ -1,0 +1,10 @@
+[](){#ref-communication-openmpi}
+# OpenMPI
+
+[Cray MPICH][ref-communication-cray-mpich] is the recommended MPI implementation on Alps.
+However, [OpenMPI](https://www.open-mpi.org/) can be used as an alternative in some cases, with limited support from CSCS.
+
+To use OpenMPI on Alps, it must be built against [libfabric][ref-communication-libfabric] with support for the [Slingshot 11 network][ref-alps-hsn].
+
+!!! todo
+    Building OpenMPI for Alps is still work in progress: https://eth-cscs.github.io/cray-network-stack/.

--- a/docs/software/communication/rccl.md
+++ b/docs/software/communication/rccl.md
@@ -1,0 +1,10 @@
+[](){#ref-communication-rccl}
+# RCCL
+
+[RCCL](https://rocmdocs.amd.com/projects/rccl/en/latest/) is an optimized inter-GPU communication library for AMD GPUs.
+It provides equivalent functionality to [NCCL][ref-communication-nccl] for AMD GPUs.
+
+!!! todo
+    - high level description
+    - libfabric/aws-ofi-rccl plugin
+    - configuration options

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,13 @@ nav:
       - 'prgenv-gnu': software/prgenv/prgenv-gnu.md
       - 'prgenv-nvfortran': software/prgenv/prgenv-nvfortran.md
       - 'linalg': software/prgenv/linalg.md
+    - 'Communication Libraries':
+      - software/communication/index.md
+      - 'Cray MPICH': software/communication/cray-mpich.md
+      - 'OpenMPI': software/communication/openmpi.md
+      - 'NCCL': software/communication/nccl.md
+      - 'RCCL': software/communication/rccl.md
+      - 'libfabric': software/communication/libfabric.md
     - 'Tools':
       - software/tools/index.md
       - 'Linaro Forge': software/tools/linaro.md


### PR DESCRIPTION
Adds a "Communication Libraries" subtree next to scientific applications and others under "Software". I've populated the Cray MPICH page with information on using GPU-aware MPI and the known issues page from the old knowledge base. Other pages (OpenMPI, NCCL, RCCL, and libfabric) are mostly stubs at the moment.