### PR TITLE
Add first version of `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @bcumming @msimberg
+* @bcumming @msimberg @RMeli
 docs/software/sciapps/cp2k @abussy @RMeli
 docs/software/communication @msimberg

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @bcumming @msimberg
+docs/software/sciapps/cp2k @abussy @RMeli
+docs/software/communication @msimberg


### PR DESCRIPTION
Adds a `CODEOWNERS` file: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.

The main benefit (IMO) is that the "code owners" for a particular file/path will automatically get requested for reviews whenever those files are changed. This means that the relevant people will automatically be at least informed about the changes.

Note that this doesn't prevent others from giving/being requested to do reviews. This just sets the default.

At the same time I think this is a good way to encode in the git repo itself who is "responsible" for the documentation for whatever definition of "responsible" we want to agree on.

I've started with the most minimal set of code owners that I could think of. I'm happy to be a default reviewer for any changes. I'm sort of assuming that @bcumming will be ok with this as well. However, I think for the top level `*` code owners it'd be good to have a few more people.

@RMeli and @abussy agreed to be code owners for the CP2K page.

I'm happy to take the "Communication Libraries" section that I added in #40.

I would like to avoid making this PR "let's exactly figure out who's responsible for what" and just have the basic version in first. We can then expand the list as we update pages and find who it makes sense to make code owner for various parts. If there are other obvious candidates at this point, please do point them out right away though and I'll add them.