### PR TITLE
Minor updates to GB low noise mode description

### DIFF
--- a/docs/guides/gb2025.md
+++ b/docs/guides/gb2025.md
@@ -50,7 +50,14 @@ Your data sets from Daint are available on Santis
 ## Low Noise Mode
 
 !!! note
-    Low noise mode has been disabled, so the previous requirement that you set `OMP_PLACES` and `OMP_PROC_BIND` no longer applies.
+    Low noise mode has been relaxed, so the previous requirement that you set `OMP_PLACES` and `OMP_PROC_BIND` no longer applies.
+    One core per module is still reserved for system processes.
+    
+Santis uses low noise mode, which reserves one core per Grace-Hopper module (i.e. per 72 cores) for system processes.
+This mode is intended to reduce performance variability caused by system processes interfering with application threads and processes.
+This means that that SLURM job scripts must be updated to account for the reserved cores.
+
+### SLURM
 
 !!! warning "Unable to allocate resources: Requested node configuration is not available"
     If you try to use all 72 cores on each socket, SLURM will give a hard error, because only 71 are available:
@@ -61,10 +68,7 @@ Your data sets from Daint are available on Santis
     srun: error: Unable to allocate resources: Requested node configuration is not available
     ```
 
-### SLURM
-
 Explicitly set the number of cores per task using the `--cpus-per-task/-c` flag, e.g.:
-For example:
 ```
 #SBATCH --cpus-per-task=64
 ```

--- a/docs/guides/gb2025.md
+++ b/docs/guides/gb2025.md
@@ -55,7 +55,7 @@ Your data sets from Daint are available on Santis
     
 Santis uses low noise mode, which reserves one core per Grace-Hopper module (i.e. per 72 cores) for system processes.
 This mode is intended to reduce performance variability caused by system processes interfering with application threads and processes.
-This means that that SLURM job scripts must be updated to account for the reserved cores.
+This means that SLURM job scripts must be updated to account for the reserved cores.
 
 ### SLURM
 


### PR DESCRIPTION
Low noise mode is still active, just in a reduced form. Updates the GB page to reflect this. I've also moved the warning about not being able to allocate all 72 cores to the `SLURM` subsection.