### PR TITLE
Ignore code blocks from spell checking

### DIFF
--- a/.github/actions/spelling/block-delimiters.list
+++ b/.github/actions/spelling/block-delimiters.list
@@ -1,0 +1,7 @@
+# generic ignore spelling block
+<!--begin no spell check-->
+<!--end no spell check-->
+
+# ignore code blocks
+```
+```

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -11,6 +11,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check spelling
         id: spelling
+        # The given commit contains preliminary, unreleased, support for ignoring
+        # whole blocks (multi-line) from spell checking. See
+        # https://github.com/check-spelling/check-spelling/commit/46c981b7c96b3777aff4fd711fc9a8f126121b04
+        # for more details. 
         uses: check-spelling/check-spelling@46c981b7c96b3777aff4fd711fc9a8f126121b04
         with:
           check_file_names: 1

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check spelling
         id: spelling
-        uses: check-spelling/check-spelling@v0.0.24
+        uses: check-spelling/check-spelling@46c981b7c96b3777aff4fd711fc9a8f126121b04
         with:
           check_file_names: 1
           post_comment: 0

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -15,6 +15,10 @@ jobs:
         # whole blocks (multi-line) from spell checking. See
         # https://github.com/check-spelling/check-spelling/commit/46c981b7c96b3777aff4fd711fc9a8f126121b04
         # for more details. 
+        # The given commit contains preliminary, unreleased, support for ignoring
+        # whole blocks (multi-line) from spell checking. See
+        # https://github.com/check-spelling/check-spelling/commit/46c981b7c96b3777aff4fd711fc9a8f126121b04
+        # for more details. 
         uses: check-spelling/check-spelling@46c981b7c96b3777aff4fd711fc9a8f126121b04
         with:
           check_file_names: 1


### PR DESCRIPTION
I also added a generic html comment marker that can be used to ignore full blocks of text (which won't show up in the rendered output because it's an html comment).

The feature seems very early, and likely to change, but I've pinned the commit, so it should keep working this way until we update the action. It's based on this commit: https://github.com/check-spelling/check-spelling/commit/46c981b7c96b3777aff4fd711fc9a8f126121b04.