### PR TITLE
add warning that the cicd docs are incomplete

### DIFF
--- a/docs/services/cicd.md
+++ b/docs/services/cicd.md
@@ -1,6 +1,11 @@
 [](){#ref-cicd}
 # Continuous Integration / Continuous Deployment (CI/CD)
 
+!!! warning
+    The CI/CD documention has not been fully ported from [the Knowledgebase](https://confluence.cscs.ch/x/UAXJMw).
+    The information here is correct, but a lot of valuable information is still missing, please rather use at this
+    moment the [old documentation](https://confluence.cscs.ch/x/UAXJMw)
+
 [](){#ref-cicd-containerized-intro}
 ## Introduction containerized CI/CD
 


### PR DESCRIPTION
Since some people are sharing the link to the new docs for CI/CD, I've added a warning at the top, that they have not been fully ported.