### PR TITLE
typo in nvfortran docs

### DIFF
--- a/docs/software/prgenv/prgenv-nvfortran.md
+++ b/docs/software/prgenv/prgenv-nvfortran.md
@@ -64,7 +64,7 @@ uenv image find prgenv-nvfortran
 uenv image find prgenv-nvfortran@*
 
 # pull a version
-uenv image find prgenv-nvfortran/24.11:v1
+uenv image pull prgenv-nvfortran/24.11:v2
 ```
 
 === "the nvfort view"


### PR DESCRIPTION
pull a version followed by uenv image find instead of uenv image pull