### PR TITLE
link to the contribution page on readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@ This repository contains the source code for CSCS' documentation hosted at [docs
 
 ## Getting Started
 
+If you want to contribute to the documentation, please follow the [contributing](https://docs.cscs.ch/contributing) process.
+
 > [!IMPORTANT]
 > to run the serve script, you need to first install [uv](https://docs.astral.sh/uv/getting-started/installation/).
 


### PR DESCRIPTION
While many people are probably coming from the docs to the repo, it is also useful to know how to contribute from the repo directly

@RMeli is never reading the readme, but I do, hence I suggest to link to the contribution process.