### PR TITLE
Add heads-up to sync the fork repository

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -43,7 +43,7 @@ To build the docs in a `site` sub-directory:
 ```
 
 !!! tip
-    If you've already created a fork repository, make sure to [keep it synced](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) to the main CSCS repository.
+    If you've already created a fork repository, make sure to [keep it synced](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) to the main CSCS repository before making further change.
 
 ## Review process
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -41,6 +41,10 @@ To build the docs in a `site` sub-directory:
 ```bash
 ./serve build
 ```
+
+!!! tip
+    If you've already created a fork repository, make sure to [keep it synced](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) to the main CSCS repository.
+
 ## Review process
 
 Documentation is owned by everybody - so don't be afraid to jump in and make changes or fixes where you see that there is something missing or outdated.


### PR DESCRIPTION
For users who desire to contribute continuously (e.g., some CSCS staff), they might already have their own fork repository. This PR added a small heads-up (or tip) on the contribution page to sync the fork repository before proceeding.