### PR TITLE
Add `HWLOC_KEEP_NVIDIA_GPU_NUMA_NODES=0` to MPS wrapper script to avoid GPU NUMA nodes

### DIFF
--- a/docs/running/slurm.md
+++ b/docs/running/slurm.md
@@ -301,7 +301,7 @@ if [[ $SLURM_LOCALID -eq 0 ]]; then
 fi
 
 # Set CUDA device
-numa_nodes=$(hwloc-calc --physical --intersect NUMAnode $(hwloc-bind --get --taskset))
+numa_nodes=$(HWLOC_KEEP_NVIDIA_GPU_NUMA_NODES=0 hwloc-calc --physical --intersect NUMAnode $(hwloc-bind --get --taskset))
 export CUDA_VISIBLE_DEVICES=$numa_nodes
 
 # Wait for MPS to start


### PR DESCRIPTION
hwloc 2.11.0 started exposing the Grace-Hopper GPU NUMA nodes by default (https://github.com/open-mpi/hwloc/blob/41030697179b16f96f7e169f4530061c5fe6803f/NEWS#L164):
```
Version 2.11.0
--------------
...
* GPU support
  + Don't hide the GPU NUMA node on NVIDIA Grace Hopper.
```

This means that the MPS wrapper script would try to set GPU NUMA nodes to silly values (GPU NUMA nodes are indexed >= 4). For example:
```
$ hwloc-calc --physical --intersect NUMAnode $(hwloc-bind socket:0 -- hwloc-bind --get --taskset) # default
0,4
$ HWLOC_KEEP_NVIDIA_GPU_NUMA_NODES=0 hwloc-calc --physical --intersect NUMAnode $(hwloc-bind socket:0 -- hwloc-bind --get --taskset) # explicitly ignoring GPU NUMA nodes
0
```

This is not yet a problem with the system hwloc (on daint at least) which is at version 2.9.0, but if it's updated or if a newer hwloc is visible in an environment the MPS wrapper script would behave weirdly.

This PR explicitly sets `HWLOC_KEEP_NVIDIA_GPU_NUMA_NODES=0` when getting the GPU index for a rank. Setting it doesn't hurt on older hwloc versions.