### PR TITLE
Add workflow for merge queue

### DIFF
--- a/.github/workflows/docs_merge_queue.yaml
+++ b/.github/workflows/docs_merge_queue.yaml
@@ -1,0 +1,25 @@
+name: build docs (merge queue)
+
+on:
+  merge_group:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - uses: actions/cache@v3
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install --upgrade pip
+      - run: |
+          pip install -r requirements.txt
+      - run: rm -rf site
+      - run: cat mkdocs.yml
+      - run: mkdocs build --strict


### PR DESCRIPTION
This adds a workflow that is triggered on the `merge_group` event. I went for a separate workflow to keep things straightforward (avoiding conditional steps etc. in other workflows), but I'm happy to try to integrate it into one of the existing workflows as well if you think that's better.

Please do not merge as is, I'd like to make sure this can be successfully merged through the merge queue.