### PR TITLE
Updated deprecated Slurm variable name

### DIFF
--- a/docs/guides/mlp_tutorials/llm-nanotron-training.md
+++ b/docs/guides/mlp_tutorials/llm-nanotron-training.md
@@ -229,7 +229,7 @@ srun -ul --environment=nanotron bash -c "
    --master-addr=\${MASTER_ADDR} \
    --master-port=\${MASTER_PORT} \
    --nnodes=\${SLURM_NNODES} \
-   --nproc-per-node=\${SLURM_GPUS_PER_TASK} \
+   --nproc-per-node=\${SLURM_GPUS_ON_NODE} \
   \"
 
   torchrun \${TORCHRUN_ARGS} run_train.py --config-file examples/config_tiny_llama_wikitext.yaml


### PR DESCRIPTION
`SLURM_GPUS_PER_TASK` seems to be deprecated on Alps. The current submission script fails because the variable is passed to torch as an empty string. `SLURM_GPUS_ON_NODE` returns the proper number.