### PR TITLE
Fix outdated reference to alps branch on cscs-reframe-tests repo

### DIFF
--- a/docs/services/cicd.md
+++ b/docs/services/cicd.md
@@ -1319,7 +1319,7 @@ This runner is a thin wrapper over the [f7t-controller](#f7t-controller).
 The machine where ReFrame is running does not have to be a powerful machine, hence it does not make sense to start the main ReFrame process from a compute node.
 It makes more sense to start the ReFrame process on a cloud machine and submit the compute jobs through FirecREST to the actual cluster.
 
-The easiest way to use the FirecREST scheduler of ReFrame is to use the configuration files that are provided in the alps branch of the [CSCS Reframe tests repository](https://github.com/eth-cscs/cscs-reframe-tests).
+The easiest way to use the FirecREST scheduler of ReFrame is to use the configuration files that are provided in the main branch of the [CSCS Reframe tests repository](https://github.com/eth-cscs/cscs-reframe-tests).
 In case you want to run ReFrame for a system that is not already available in this directory, please open a ticket to the Service Desk and we will add it or help you update one of the existing ones.
 
 Something you should be aware of when running with this scheduler is that ReFrame will not have direct access to the filesystem of the cluster so the stage directory will need to be kept in sync through FirecREST.
@@ -1327,7 +1327,7 @@ It is recommended to try to clean the stage directory whenever possible with the
 Normally ReFrame stores these files in `~/.reframe/topology/{system}-{part}/processor.json`, but you get a "clean" runner every time.
 You could either add them in the configuration files or store the files in the first run and copy them to the right directory before ReFrame runs.
 
-Finally, you can find some more information [in the repository](https://github.com/eth-cscs/cscs-reframe-tests/blob/alps/config/systems-firecrest/README.md).
+Finally, you can find some more information [in the repository](https://github.com/eth-cscs/cscs-reframe-tests/blob/main/config/systems-firecrest/README.md).
 
 The default command that is executed is
 ```console
@@ -1355,7 +1355,7 @@ The path to the checks that is passed to `reframe` through `-c`.
 ```yaml
 job:
   before_script:
-    - git clone -b alps https://github.com/eth-cscs/cscs-reframe-tests
+    - git clone https://github.com/eth-cscs/cscs-reframe-tests
     - pip install -r cscs-reframe-tests/config/utilities/requirements.txt
     - sed -i -e "s/account=csstaff/account=$CSCS_CI_DEFAULT_SLURM_ACCOUNT/" cscs-reframe-tests/config/systems-firecrest/eiger.py
   variables:


### PR DESCRIPTION
All changes from the `alps` branch have already been merged into `main`.