### PR TITLE
Document new issue with older CP2K uenvs in Eiger

### DIFF
--- a/docs/software/sciapps/cp2k.md
+++ b/docs/software/sciapps/cp2k.md
@@ -422,6 +422,20 @@ See [manual.cp2k.org/CMake] for more details.
 
 ## Known issues
 
+### Older uenv versions on Eiger
+
+After the migration to Eiger.Alps, calculations relying on older uenvs versions (`2024.1:v1`, `2024.2:v1`, `2024.3:v1`) sometimes crash unexpectedly. The problem has been identify as coming from the `libxsmm` library, used as a backend in DBCSR. To avoid this issue, it is recommended to upgrade to a newer uenv.
+
+In case a spcefic 2024.x version of CP2K is required, crashes can be avoided by switching to the `BLAS` backend of DBCSR. This can be done by adding the following in the `&GLOBAL` subsection of the input file:
+
+```bash
+&GLOBAL
+    &DBCSR
+        MM_DRIVER BLAS
+    &END DBCSR
+&END GLOBAL
+```
+
 ### DLA-Future
 
 The `cp2k/2025.1:v2` uenv provides CP2K with [DLA-Future] support enabled, in the `cp2k-dlaf` view.

--- a/docs/software/sciapps/cp2k.md
+++ b/docs/software/sciapps/cp2k.md
@@ -426,7 +426,7 @@ See [manual.cp2k.org/CMake] for more details.
 
 After the migration to Eiger.Alps, calculations relying on older uenv versions (`2024.1:v1`, `2024.2:v1`, `2024.3:v1`) sometimes crash unexpectedly with a segmentation fault. The problem has been identify as coming from the `libxsmm` library, used as a backend in DBCSR. To avoid this issue, it is recommended to upgrade to a newer uenv.
 
-In case a spcefic `2024.x` version of CP2K is required, crashes can be avoided by switching to the `BLAS` backend of DBCSR. This can be done by adding the following in the `&GLOBAL` subsection of the input file:
+In case a specific `2024.x` version of CP2K is required, crashes can be avoided by switching to the `BLAS` backend of DBCSR. This can be done by adding the following in the `&GLOBAL` subsection of the input file:
 
 ```bash
 &GLOBAL

--- a/docs/software/sciapps/cp2k.md
+++ b/docs/software/sciapps/cp2k.md
@@ -424,9 +424,9 @@ See [manual.cp2k.org/CMake] for more details.
 
 ### Older uenv versions on Eiger
 
-After the migration to Eiger.Alps, calculations relying on older uenvs versions (`2024.1:v1`, `2024.2:v1`, `2024.3:v1`) sometimes crash unexpectedly. The problem has been identify as coming from the `libxsmm` library, used as a backend in DBCSR. To avoid this issue, it is recommended to upgrade to a newer uenv.
+After the migration to Eiger.Alps, calculations relying on older uenv versions (`2024.1:v1`, `2024.2:v1`, `2024.3:v1`) sometimes crash unexpectedly with a segmentation fault. The problem has been identify as coming from the `libxsmm` library, used as a backend in DBCSR. To avoid this issue, it is recommended to upgrade to a newer uenv.
 
-In case a spcefic 2024.x version of CP2K is required, crashes can be avoided by switching to the `BLAS` backend of DBCSR. This can be done by adding the following in the `&GLOBAL` subsection of the input file:
+In case a spcefic `2024.x` version of CP2K is required, crashes can be avoided by switching to the `BLAS` backend of DBCSR. This can be done by adding the following in the `&GLOBAL` subsection of the input file:
 
 ```bash
 &GLOBAL


### PR DESCRIPTION
Document a workaround to avoid crashes with older CP2K uenvs on Eiger.Alps (which appeared after the migration).