### PR TITLE
Add clear reminder to check known issues with CP2K

### DIFF
--- a/docs/software/sciapps/cp2k.md
+++ b/docs/software/sciapps/cp2k.md
@@ -15,6 +15,9 @@ transition state optimization using NEB or dimer method. See [CP2K Features] for
     [CP2K] is provided on [ALPS][platforms-on-alps] via [uenv][ref-uenv].
     Please have a look at the [uenv documentation][ref-uenv] for more information about uenvs and how to use them.
 
+!!! note "Known issues"
+    Please check CP2K's [known issues](#known-issues) and whether they are relevant to your work. They may impact your calculations in subtle ways, potentially leading to a waste of resources.
+
 ??? note "Changelog"
 
     ??? note "2025.1"

--- a/docs/software/sciapps/cp2k.md
+++ b/docs/software/sciapps/cp2k.md
@@ -15,7 +15,7 @@ transition state optimization using NEB or dimer method. See [CP2K Features] for
     [CP2K] is provided on [ALPS][platforms-on-alps] via [uenv][ref-uenv].
     Please have a look at the [uenv documentation][ref-uenv] for more information about uenvs and how to use them.
 
-!!! note "Known issues"
+!!! warning "Known issues"
     Please check CP2K's [known issues](#known-issues) and whether they are relevant to your work. They may impact your calculations in subtle ways, potentially leading to a waste of resources.
 
 ??? note "Changelog"


### PR DESCRIPTION
I have a strong feeling that many users do not read the full CP2K documentation and miss the important `Known issues` section. This leads to sub-optimal runs and waste of resources. This should hopefully help.