### PR TITLE
fix uenv-runner --> uenv-builder

### DIFF
--- a/docs/services/cicd.md
+++ b/docs/services/cicd.md
@@ -1118,7 +1118,7 @@ job2:
     - ci/upload_code_coverage.sh
 ```
 
-### uenv-runner
+### uenv-builder
 This runner submits SLURM jobs through FirecREST.
 See the [comments below](#firecrest) and the [FirecREST documentation][ref-firecrest] for additional FirecREST information.
 


### PR DESCRIPTION
The title of `uenv-builder` was mistakenly named `uenv-runner`.