### PR TITLE
Fix a typo in an [env] block example for EDF

### DIFF
--- a/docs/software/container-engine/edf.md
+++ b/docs/software/container-engine/edf.md
@@ -168,15 +168,15 @@ Environment variables to set in the container. Empty string values will unset th
      * Basic `env` block
         ```toml
         [env]
-        MY_RUN = "production",
+        MY_RUN = "production"
         DEBUG = "false"
         ```
 
      * Use of environment variable expansion
         ```toml
         [env]
-        MY_NODE = "${VAR_FROM_HOST}",
-        PATH = "${PATH}:/custom/bin", 
+        MY_NODE = "${VAR_FROM_HOST}"
+        PATH = "${PATH}:/custom/bin"
         DEBUG = "true"
         ```
 


### PR DESCRIPTION
There was a typo in the example for the `[env]` EDF block, discovered by @fcruzcscs .