### PR TITLE
Add a warning message about "--environment in SBATCH"

### DIFF
--- a/docs/software/container-engine/run.md
+++ b/docs/software/container-engine/run.md
@@ -15,7 +15,7 @@ There are three ways to do so:
     $ srun --environment=./.edf/ubuntu.toml echo "Hello"    # from ${HOME}. 
     ```
 
- 3. **From EDF search paths**: the name of EDF in the [EDF search path][ref-ce-edf-search-path]. Notice that `--environment` accepts the EDF filename **without** the `.toml` extension:
+ 3. **From EDF search paths**: the name of EDF in the [EDF search path][ref-ce-edf-search-path]. Notice that in this way, `--environment` accepts the EDF filename **without** the `.toml` extension.
 
     ```console 
     $ srun --environment=ubuntu echo "Hello" 

--- a/docs/software/container-engine/run.md
+++ b/docs/software/container-engine/run.md
@@ -15,7 +15,7 @@ There are three ways to do so:
     $ srun --environment=./.edf/ubuntu.toml echo "Hello"    # from ${HOME}. 
     ```
 
- 3. **From EDF search paths**: the name of EDF in the [EDF search path][ref-ce-edf-search-path]. `--environment` also accepts the EDF filename without the `.toml` extension:
+ 3. **From EDF search paths**: the name of EDF in the [EDF search path][ref-ce-edf-search-path]. Notice that `--environment` accepts the EDF filename **without** the `.toml` extension:
 
     ```console 
     $ srun --environment=ubuntu echo "Hello" 

--- a/docs/software/container-engine/run.md
+++ b/docs/software/container-engine/run.md
@@ -39,9 +39,8 @@ Use `--environment` with the Slurm command (e.g., `srun` or `salloc`):
 Specifying the `--environment` option with an `#SBATCH` option is **experimental**. 
 Such usage is discouraged as it may result in unexpected behaviors.
 
-!!! note
-    Specifying `--environment` with `#SBATCH` will put the entire batch script inside the containerized environment, requiring the Slurm hook to use any Slurm commands within the batch script (e.g., `srun` or `scontrol`). 
-    The hook is controlled by the `ENROOT_SLURM_HOOK` environment variable and activated by default on most vClusters.
+!!! warning 
+    The use of `--environment` as an `#SBATCH` option is reserved for highly customized workflows, and it may result in several **counterintuitive, hard-to-diagnose failures**. See [Why `--environment` as `#SBATCH` is discouraged][ref-ce-why-no-sbatch-env] for details.
 
 [](){#ref-ce-edf-search-path}
 ### EDF search path


### PR DESCRIPTION
Resolves: [VCUE-1014](https://jira.cscs.ch/browse/VCUE-1014)

As specifying "--environment" as an "#SBATCH" option has caused many nonsensical problems, the container team decided to add an explicit warning (alongside some mitigations to known errors). To avoid distraction, the warning message was kept short in the main usage page ("Using container engine") and linked to the main warning message ("Known issues").