### PR TITLE
Add a warning message about "--environment in SBATCH"

### DIFF
--- a/docs/software/container-engine/known-issue.md
+++ b/docs/software/container-engine/known-issue.md
@@ -56,7 +56,8 @@ Defining a mount related to `/users` in the EDF should only be done when there i
 [](){#ref-ce-why-no-sbatch-env}
 ## Why `--environment` as `#SBATCH` is discouraged
 
-Due to how Slurm works, when using `--environment` as an `#SBATCH` option, the entire content of the SBATCH script is executed within a container created by the EDF file. This may cause several counterintuitive implications that can lead to subtle and hard-to-diagnose failures. The following are a few known issues associated with `--environment` in SBATCH.
+Due to how Slurm works, when using `--environment` as an `#SBATCH` option, the entire contents of the SBATCH script is executed within a container created by the EDF file.
+This can lead to subtle and hard-to-diagnose failures, some of which are described below.
 
  - **Slurm availability in the container**: In some cases, CE does not inject essential Slurm components in containers, which result in crashes on basic Slurm operations (e.g., `srun`) inside the SBATCH script. Even if they were injected, it's not guaranteed to cover the complete feature set of Slurm.
 

--- a/docs/software/container-engine/run.md
+++ b/docs/software/container-engine/run.md
@@ -37,7 +37,7 @@ Use `--environment` with the Slurm command (e.g., `srun` or `salloc`):
     srun --environment=ubuntu cat /etc/os-release
     ```
 
-Multiple Slurm commands may have different EDF environments; this is useful when a single environment is not feasible due to the compatibility issues between programs.
+Multiple Slurm commands may have different EDF environments; this is useful when a single environment is not feasible due to compatibility issues or keep EDF files modular.
 
 !!! example "`srun`s with different EDFs"
     ```bash

--- a/docs/software/container-engine/run.md
+++ b/docs/software/container-engine/run.md
@@ -42,9 +42,8 @@ Use `--environment` with the Slurm command (e.g., `srun` or `salloc`):
 Specifying the `--environment` option with an `#SBATCH` option is **experimental**. 
 Such usage is discouraged as it may result in unexpected behaviors.
 
-!!! note
-    Specifying `--environment` with `#SBATCH` will put the entire batch script inside the containerized environment, requiring the Slurm hook to use any Slurm commands within the batch script (e.g., `srun` or `scontrol`). 
-    The hook is controlled by the `ENROOT_SLURM_HOOK` environment variable and activated by default on most vClusters.
+!!! warning 
+    The use of `--environment` as an `#SBATCH` option is reserved for highly customized workflows, and it may result in several **counterintuitive, hard-to-diagnose failures**. See [Why `--environment` as `#SBATCH` is discouraged][ref-ce-why-no-sbatch-env] for details.
 
 [](){#ref-ce-edf-search-path}
 ### EDF search path

--- a/docs/software/container-engine/run.md
+++ b/docs/software/container-engine/run.md
@@ -34,10 +34,24 @@ Use `--environment` with the Slurm command (e.g., `srun` or `salloc`):
     #SBATCH --job-name=edf-example
     #SBATCH --time=00:01:00
     ...
-
-    # Run job step
     srun --environment=ubuntu cat /etc/os-release
     ```
+
+Multiple Slurm commands may have different EDF environments; this is useful when a single environment is not feasible due to the compatibility issues between programs.
+
+!!! example "`srun`s with different EDFs"
+    ```bash
+    #!/bin/bash
+    #SBATCH --job-name=edf-example
+    #SBATCH --time=00:01:00
+    ...
+    srun --environment=env1 ... # (1)! 
+    ...
+    srun --environment=env2 ... # (2)!
+    ```
+    
+    1. Assuming `env1.toml` is at `EDF_PATH`. See [EDF search path][ref-ce-edf-search-path] below.
+    2. Assuming `env2.toml` is at `EDF_PATH`. See [EDF search path][ref-ce-edf-search-path] below.
 
 Specifying the `--environment` option with an `#SBATCH` option is **experimental**. 
 Such usage is discouraged as it may result in unexpected behaviors.


### PR DESCRIPTION
Resolves: [VCUE-1014](https://jira.cscs.ch/browse/VCUE-1014)

As specifying "--environment" as an "#SBATCH" option has caused many nonsensical problems, the container team decided to add an explicit warning (alongside some mitigations to known errors). To avoid distraction, the warning message was kept short in the main usage page ("Using container engine") and linked to the main warning message ("Known issues").