### PR TITLE
Remove kb banner and align status.cscs.ch box

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,7 @@
 # CSCS Documentation
 
 <div class="grid cards" markdown>
--    Visit the CSCS status site for the status of Alps systems, and the latest announcements.
-
-
-    [:octicons-arrow-right-24: status.cscs.ch](https://status.cscs.ch/)
+-   <p style="text-align:center">Visit <a href="https://status.cscs.ch/">status.cscs.ch</a> for the status of Alps systems, and the latest announcements.</p>
 </div>
 
 The Alps Research infrastructure hosts multiple platforms and clusters targeting different communities

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,14 +1,3 @@
 {% extends "base.html" %}
 
-{% block announce %}
-
-<p>
-This is the new CSCS documentation site, which replaces the <a href="https://confluence.cscs.ch/display/KB">CSCS Knowledge Base</a>.
-</p>
-
-<p>
-The migration of old documentation is still not fully complete.
-If you find documentation that is missing, please create a ticket on the documentation's <a href="https://github.com/eth-cscs/cscs-docs/issues">GitHub issue tracker</a>.
-</p>
-
-{% endblock %}
+<!-- add announcement banner here -->


### PR DESCRIPTION
Small readbility improvements for users who land on the main index page.

* remove the banner that links to the old KB - this hasn't generated any tickets, and we have had enough time for users to get used to the new site
* reduce text and add centering to the link to the status page at the top of the main index page to reduce clutter