### PR TITLE
Make contributing guidelines more visible

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,3 @@
 # Contributing
 
 Please take some time to get familiar with the [contributing guidelines](https://docs.cscs.ch/contributing/) before making your first contribution.
-Following the guidelines helps us keep the documentation consistent and as useful as possible for users.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing
+
+Please take some time to get familiar with the [contributing guidelines](https://docs.cscs.ch/contributing/) before making your first contribution.
+Following the guidelines helps us keep the documentation consistent and as useful as possible for users.

--- a/.github/workflows/welcome.yaml
+++ b/.github/workflows/welcome.yaml
@@ -1,0 +1,21 @@
+name: First interaction message
+
+on:
+  pull_request_target:
+    types: [opened]
+    branches:
+      - main
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - uses: actions/first-interaction@v3
+      with:
+        pr-message: |
+          Thank you for your contribution to eth-cscs/cscs-docs.
+
+          If you have not done so already, please take some time to get familiar with the [contributing guidelines](https://docs.cscs.ch/contributing/).
+          Following the guidelines helps us keep the documentation consistent and as useful as possible for users.


### PR DESCRIPTION
- Adds a `CONTRIBUTING.md` file (which simply links to the contributing guidelines in the docs) to improve visibility. The `CONTRIBUTING.md` file is shown on the main repo page.
- Adds a first-interaction github workflow which also guides contributors to the guidelines in case they missed the guidelines before opening a PR. A comment with a link to the guidelines is posted on PRs from first-time contributors.