### PR TITLE
Fix a wrong EDF field reference

### DIFF
--- a/docs/software/container-engine/edf.md
+++ b/docs/software/container-engine/edf.md
@@ -93,16 +93,16 @@ Initial working directory when the container starts.
 
 ### `entrypoint`
 
- |             |        |
- |-------------|--------|
- | **Type**    | bool   |
- | **Default** | `true` |
+ |             |         |
+ |-------------|---------|
+ | **Type**    | bool    |
+ | **Default** | `false` |
 
 If true, run the entrypoint from the container image.
 
 !!! example
     ```toml
-    entrypoint = false
+    entrypoint = true
     ```
 
 ### `writable`


### PR DESCRIPTION
While dealing with a user ticket [SD-66984](https://jira.cscs.ch/browse/SD-66984), we noticed that an EDF reference is specifying a wrong default value for the field `entrypoint`. This PR fixed it.