### PR TITLE
update uenv release notes; uenv->uenvs for more than one uenv

### DIFF
--- a/docs/software/uenv/build.md
+++ b/docs/software/uenv/build.md
@@ -1,9 +1,9 @@
 [](){#ref-uenv-build}
-# Building uenv
+# Building uenvs
 
 ## uenv build service
 
-CSCS provides a build service for uenv that takes as its input a uenv recipe, and builds the uenv using the same pipeline used to build the officially supported uenv.
+CSCS provides a build service for uenvs that takes as its input a uenv recipe, and builds the uenv using the same pipeline used to build the officially supported uenv.
 
 The command takes two arguments:
 

--- a/docs/software/uenv/configure.md
+++ b/docs/software/uenv/configure.md
@@ -1,7 +1,7 @@
 [](){#ref-uenv-configure}
-# Configuring uenv
+# Configuring uenvs
 
-Uenv is designed to work out of the box, with zero configuration for most users.
+The uenv tools are designed to work out of the box, with zero configuration for most users.
 There is support for limited per-user configuration via a configuration file, which will be expanded as we add features that make it easier for groups and communities to manage their own environments.
 
 ## User configuration

--- a/docs/software/uenv/deploy.md
+++ b/docs/software/uenv/deploy.md
@@ -1,5 +1,5 @@
 [](){#ref-uenv-deploy}
-# Deploying uenv
+# Deploying uenvs
 
 [](){#ref-uenv-deploy-versions}
 ## Versioning and labeling
@@ -18,7 +18,8 @@ prgenv-gnu/24.11:v2@todi%gh200
 
 ### uenv name
 
-The name of the uenv. In this case `prgenv-gnu`.
+The name of the uenv.
+In this case `prgenv-gnu`.
 
 ### uenv version
 
@@ -117,7 +118,7 @@ recipes to deployed versions on microarchitectures.
 !!! note "For CSCS staff"
     This information applies only to CSCS staff.
 
-Deployment and deletion of uenv requires elevated permissions.
+Deployment and deletion of uenvs requires elevated permissions.
 Before you can modify the uenv registry, you need to set up credentials.
 
 * Your CSCS username needs to be added to the `uenv-admin` group on JFrog, and
@@ -209,8 +210,8 @@ These artifacts are stored in a JFrog "generic repository" [uenv-sources].
 
 Each software package has a sub-directory and all image paths are lower case (e.g. `uenv-sources/namd`).
 
-By default, all packages in [uenv-sources]  are anonymous read access
-to enable users to build uenv on vClusters without configuring access tokens.
+By default, all packages in [uenv-sources] are anonymous read access
+to enable users to build uenvs on vClusters without configuring access tokens.
 However,
 
 * access to some packages is restricted by applying access rules to the package path
@@ -236,9 +237,9 @@ For this reason, there is not a universal release and deprecation schedule for s
 While the frequency of updates and deprecation policy is defined by the uenv maintainer, the following release cycle with tag names should be followed when possible:
 
 - [optional] tag pre-releases with `:rc1`, `:rc2`, etc
-    - uenv tagged as release candidates are intended for early testing only, and can be removed at any point.
+    - uenvs tagged as release candidates are intended for early testing only, and can be removed at any point.
 - Tag `:v1` for the first official release.
-- [optional] release updated versions of uenv with tags (`:v2`, `:v3`, ...) with patches and fixes.
+- [optional] release updated versions of a uenv with tags (`:v2`, `:v3`, ...) with patches and fixes.
 - Remove old versions according to a deprecation policy.
 
 A uenv's release and support policy is part of the uenv's documentation under the "Versioning" section, see [prgenv-gnu][ref-uenv-prgenv-gnu-versioning] for example.

--- a/docs/software/uenv/index.md
+++ b/docs/software/uenv/index.md
@@ -1,8 +1,8 @@
 [](){#ref-uenv}
 # uenv
 
-Uenv are user environments that provide scientific applications, libraries and tools.
-Uenv are typically application-specific, domain-specific or tool-specific - each uenv contains only what is required for the application or tools that it provides.
+Uenvs are user environments that provide scientific applications, libraries and tools.
+Uenvs are typically application-specific, domain-specific or tool-specific - each uenv contains only what is required for the application or tools that it provides.
 
 Each uenv is packaged in a single file (in the [Squashfs](https://docs.kernel.org/filesystems/squashfs.html) file format), that stores a compressed directory tree that contains all of the software, tools and other information like modules, required to provide a rich environment.
 
@@ -25,15 +25,15 @@ They cover everything you need to get started with using uenv to build your code
 
 -   :fontawesome-solid-layer-group: __Managing uenv__
 
-    Uenv need to be downloaded before they can be used.
+    Uenvs need to be downloaded before they can be used.
 
     Learn how to search for, download and manage uenv images.
 
-    [:octicons-arrow-right-24: Managing uenv][ref-uenv-manage]
+    [:octicons-arrow-right-24: Managing uenvs][ref-uenv-manage]
 
 -   :fontawesome-solid-layer-group: __uenv guides__
 
-    Guides and useful information, including how uenv are named and referenced:
+    Guides and useful information, including how uenvs are named and referenced:
 
     [:octicons-arrow-right-24: uenv naming][ref-uenv-labels]
 
@@ -50,15 +50,15 @@ The following guides provide for advanced users and CSCS staff:
 
 -   :fontawesome-solid-layer-group: __Building uenv__
 
-    More adventurous users can create their own uenv for personal use, and for other users in their team and community.
+    More adventurous users can create their own uenvs for personal use, and for other users in their team and community.
 
-    [:octicons-arrow-right-24: Building uenv][ref-uenv-build]
+    [:octicons-arrow-right-24: Building uenvs][ref-uenv-build]
 
 -   :fontawesome-solid-layer-group: __Configuring uenv__
 
     Users can customize the behavior of uenv using a configuration file.
 
-    [:octicons-arrow-right-24: Configuring uenv][ref-uenv-configure]
+    [:octicons-arrow-right-24: Configuring uenvs][ref-uenv-configure]
 
 -   :fontawesome-solid-layer-group: __Release notes__
 
@@ -74,7 +74,7 @@ The following guides provide for advanced users and CSCS staff:
 
     **For CSCS staff**, though it may be of interest to advanced users.
 
-    [:octicons-arrow-right-24: Deploying uenv][ref-uenv-deploy]
+    [:octicons-arrow-right-24: Deploying uenvs][ref-uenv-deploy]
 
 
 </div>
@@ -88,21 +88,19 @@ After logging into an [Alps cluster][ref-alps-clusters], you can quickly check t
 $ uenv status
 there is no uenv loaded
 $ uenv --version
-9.0.0
+9.1.0
 ```
 
-On Alps clusters the current versions are available
+[Version 9][ref-uenv-release-notes-v9.0.0] of uenv is installed on the main Alps clusters, specifically the following versions:
 
 | version | description |
 | -- | -- |
-| 9.0.0 | currently installed on [Eiger][ref-cluster-eiger], [Daint][ref-cluster-daint], [Clariden][ref-cluster-clariden] and [Santis][ref-cluster-santis] |
-| 9.0.1 | bug fix release that will be deployed mid November 2025 |
-| 9.1.0 | feature release, currently being tested. Will be deployed late November 2025  |
+| [9.1.0][ref-uenv-release-notes-v9.1.0] | currently installed on [Eiger][ref-cluster-eiger], [Daint][ref-cluster-daint], [Clariden][ref-cluster-clariden] and [Santis][ref-cluster-santis] |
+| [9.1.0][ref-uenv-release-notes-v9.1.1] | feature bug fix release, currently being tested. |
 
-Uenv are fully self-contained environments stored in a single SquashFS file.
-In order to use a uenv, it first has to be downloaded into a local file system.
+See the [uenv release notes][ref-uenv-release-notes] for more information about features, fixes and known issues in each version.
 
-The `uenv` command line tool is the main tool used to interact with uenv.
+The `uenv` command line tool is the main tool used to interact with uenvs.
 The basic workflow for using a uenv provided by CSCS is:
 
 * search for available images using `uenv image find`

--- a/docs/software/uenv/index.md
+++ b/docs/software/uenv/index.md
@@ -96,7 +96,7 @@ $ uenv --version
 | version | description |
 | -- | -- |
 | [9.1.0][ref-uenv-release-notes-v9.1.0] | currently installed on [Eiger][ref-cluster-eiger], [Daint][ref-cluster-daint], [Clariden][ref-cluster-clariden] and [Santis][ref-cluster-santis] |
-| [9.1.0][ref-uenv-release-notes-v9.1.1] | feature bug fix release, currently being tested. |
+| [9.1.1][ref-uenv-release-notes-v9.1.1] | feature bug fix release, currently being tested. |
 
 See the [uenv release notes][ref-uenv-release-notes] for more information about features, fixes and known issues in each version.
 

--- a/docs/software/uenv/index.md
+++ b/docs/software/uenv/index.md
@@ -96,7 +96,7 @@ $ uenv --version
 | version | description |
 | -- | -- |
 | [9.1.0][ref-uenv-release-notes-v9.1.0] | currently installed on [Eiger][ref-cluster-eiger], [Daint][ref-cluster-daint], [Clariden][ref-cluster-clariden] and [Santis][ref-cluster-santis] |
-| [9.1.1][ref-uenv-release-notes-v9.1.1] | feature bug fix release, currently being tested. |
+| [9.1.1][ref-uenv-release-notes-v9.1.1] | a bug fix release, currently being tested. |
 
 See the [uenv release notes][ref-uenv-release-notes] for more information about features, fixes and known issues in each version.
 

--- a/docs/software/uenv/management.md
+++ b/docs/software/uenv/management.md
@@ -1,5 +1,5 @@
 [](){#ref-uenv-manage}
-# Managing uenv
+# Managing uenvs
 
 This page documents how to search for, download and manage your local uenv images.
 

--- a/docs/software/uenv/release-notes.md
+++ b/docs/software/uenv/release-notes.md
@@ -4,6 +4,7 @@
 The latest version of uenv deployed on [Alps clusters][ref-alps-clusters] is **v8.1.0**.
 You can check the version available on a specific system with the `uenv --version` command.
 
+
 [](){#ref-uenv-release-notes-v9.0.0}
 ## v9.0.0
 
@@ -36,9 +37,29 @@ This [version](https://github.com/eth-cscs/uenv2/releases/tag/v9.0.0) will repla
     This version introduced changes to the `squashfs-mount` tool used by `uenv start` and `uenv -run` that are incompatible with older versions of uenv.
     If you see errors that contain `error: unable to exec '...': No such file or directory (errno=2)`, follow the guide for [uninstalling user-installed uenv][ref-uenv-uninstall].
 
-!!! warning "bash: module: command not found"
-    This is a known issue with version 9.0.0 that will be fixed in 9.0.1.
+??? warning "bash: module: command not found"
+    This is a known issue with version 9.0.0 that was be fixed in 9.0.1, and should no longer be an issue on Alps.
     See the [uenv modules][ref-uenv-error-v9modules] docs for a workaround.
+
+### Minor and Patch releases
+
+[](){#ref-uenv-release-notes-v9.1.1}
+??? info "v9.1.1 bug fix release"
+    - [fix] rename cluster field in elastic logs to avoid name conflict
+    - [fix] clean up `uenv status --format=views` output
+    - [fix] restrict lustre striping to max 32 OST
+
+[](){#ref-uenv-release-notes-v9.1.0}
+??? info "v9.1.0 feature release"
+    A feature release that focussed on managing repositories
+
+    - [feature] add support for lustre striping and cleaning up missing images from repos
+    - [feature] add `uenv repo migrate` feature
+
+[](){#ref-uenv-release-notes-v9.0.1}
+??? info "v9.0.1 bug fix release"
+    - [fix] fix bash function forwarding bug that broke the module command
+
 
 [](){#ref-uenv-release-notes-v8.1.0}
 ## v8.1.0

--- a/docs/software/uenv/release-notes.md
+++ b/docs/software/uenv/release-notes.md
@@ -38,10 +38,10 @@ This [version](https://github.com/eth-cscs/uenv2/releases/tag/v9.0.0) will repla
     If you see errors that contain `error: unable to exec '...': No such file or directory (errno=2)`, follow the guide for [uninstalling user-installed uenv][ref-uenv-uninstall].
 
 ??? warning "bash: module: command not found"
-    This is a known issue with version 9.0.0 that was be fixed in 9.0.1, and should no longer be an issue on Alps.
+    This is a known issue with version 9.0.0 that was fixed in 9.0.1, and should no longer be an issue on Alps.
     See the [uenv modules][ref-uenv-error-v9modules] docs for a workaround.
 
-### Minor and Patch releases
+### Minor and patch releases
 
 [](){#ref-uenv-release-notes-v9.1.1}
 ??? info "v9.1.1 bug fix release"

--- a/docs/software/uenv/using.md
+++ b/docs/software/uenv/using.md
@@ -1,19 +1,19 @@
 [](){#ref-uenv-using}
-# Using uenv
+# Using uenvs
 
 To use one, it must first be loaded into your running environment.
-There are three ways to use uenv:
+There are three ways to use a uenv:
 
 * [**Start**][ref-uenv-start] a shell with a uenv environment for **interactive use**;
 * [**Run**][ref-uenv-run] a single command in a uenv, for use in scripts or in workflows that use software provided by more than one uenv.
 * Configure a [**Slurm**][ref-uenv-slurm] job to use a uenv on compute nodes.
 
 [](){#ref-uenv-how}
-## How uenv work
+## How uenv works
 
-Uenv provide full software stacks that provide specific applications, or programming/development environments.
-Uenv are [SquashFS images](https://docs.kernel.org/filesystems/squashfs.html), a compressed file that contains a directory tree.
-The squashfs image of a uenv is a directory that contains all of the software provided by the uenv, along with useful meta data.
+A uenv provides full software stacks that provide specific applications, or programming/development environments.
+They are stored as [SquashFS images](https://docs.kernel.org/filesystems/squashfs.html), a compressed file that contains a directory tree.
+The SquashFS image of a uenv is a directory that contains all of the software provided by the uenv, along with useful meta data.
 
 
 When you use [`uenv start`][ref-uenv-start], [`uenv run`][ref-uenv-run], or use the [`--uenv`][ref-uenv-slurm] flag with Slurm, the SquashFS file is mounted at the mount location for the uenv, which is most often `/user-environment`.
@@ -366,7 +366,7 @@ This is a little bit inconvenient, and we will add a command for finding the vie
 [](){#ref-uenv-views-modules}
 ### Modules view
 
-Most uenv provide the modules, that can be accessed using the `module` command.
+Most uenvs provide the modules, that can be accessed using the `module` command.
 By default, the modules are not activated when a uenv is started, and need to be explicitly activated using the `module` view.
 
 !!! example "using the module view"


### PR DESCRIPTION
This is a quick update that:

- updates the release notes for uenv with notes about 9.0.1, 9.1.0, 9.1.1
- cleans up references to some bugs since uenv has been upgraded to 9.1.0 on the main systems
- start converting the docs to use uenvs as the plural of uenv (seems like I was the only person on earth who thought that uenv should be the plural of uenv).