### PR TITLE
Update uenv-spack docs

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -254,6 +254,7 @@ kubeconfig
 ceph
 rwx
 rwo
+standalone
 subdomain
 tls
 kured

--- a/docs/build-install/uenv.md
+++ b/docs/build-install/uenv.md
@@ -115,7 +115,7 @@ The `uenv-spack` tool can be used to create a build directory with a template [S
     ./build
     ```
 
-    1. Edit the [`spack.yaml`][Spack environment file] file to add package specs, set perferences, etc.
+    1. Edit the [`spack.yaml`][Spack environment file] file to add package specs, set preferences, etc.
 
     All of the arguments are required:
 

--- a/docs/build-install/uenv.md
+++ b/docs/build-install/uenv.md
@@ -19,15 +19,16 @@ CSCS provides `uenv-spack` - a tool that can be used to quickly install software
 
 ```bash
 git clone https://github.com/eth-cscs/uenv-spack.git # (1)!
-
-(cd uenv-spack && ./bootstrap) # (2)!
-
-export PATH=$PWD/uenv-spack:$PATH
+export PATH=$PWD/uenv-spack:$PATH  # (2)!
 ```
 
 1. Download the `uenv-spack` tool from GitHub.
 
-2. Initialize the `uenv-spack` tool.
+2. Makes the `uenv-spack` executable available.
+
+!!! note "Requires uv"
+    `uenv-spack` requires that [uv](https://docs.astral.sh/uv/) is installed to work.
+    See our guide to setting up [installation locations][ref-guides-terminal-arch], before [installing uv](https://docs.astral.sh/uv/getting-started/installation).
 
 ### Select the uenv
 
@@ -59,7 +60,7 @@ uenv start prgenv-gnu/24.11:v1 --view=spack
 
 !!! note "What does the `spack` view do?"
     The `spack` view sets environment variables that provide information about the version of Spack that was used to build the uenv, and where the uenv Spack configuration is stored.
-    
+
     | <div style="width:12em">variable</div> | <div style="width:18em">example</div> | description |
     | -------- | ------- | ----------- |
     | `UENV_SPACK_CONFIG_PATH` | `user-environment/config` | the path of the upstream [spack configuration files]. |
@@ -67,7 +68,16 @@ uenv start prgenv-gnu/24.11:v1 --view=spack
     | `UENV_SPACK_URL`         | `https://github.com/spack/spack.git` | The git repository for Spack - nearly always the main spack/spack repository. |
     | `UENV_SPACK_COMMIT`      | `c6d4037758140fe...0cd1547f388ae51` | The commit of Spack that was used |
 
-    !!! warning
+    Spack version 1 moved the Spack packages from inside the Spack repository to a stand alone [repository on GitHub](https://github.com/spack/spack-packages).
+    Uenvs that were built using Spack 1.0 and later will also set the following environment variables that provide information about the package versioning:
+
+    | <div style="width:14em">variable</div> | <div style="width:16em">example</div> | description |
+    | -------- | ------- | ----------- |
+    | `UENV_SPACK_PACKAGES_REF`         | `releases/v2025.07` | the branch or tag used - this might be empty if a specific commit of Spack was used. |
+    | `UENV_SPACK_PACKAGES_URL`         | `https://github.com/spack/spack-packages.git` | The git repository - nearly always the main spack/spack-packages repository. |
+    | `UENV_SPACK_PACKAGES_COMMIT`      | `c6d4037758140fe...0cd1547f388ae51` | The git commit of Spack-packages that was used |
+
+    !!! note
 
         The environment variables set by the `spack` view are scoped by `UENV_`.
         Therefore, they don't change Spack-related environment variables.

--- a/docs/build-install/uenv.md
+++ b/docs/build-install/uenv.md
@@ -240,7 +240,7 @@ The packages built by Spack are installed in `<build-path>/store`.
 ### Spack view
 
 A Spack view is generated in `<build-path>/view`, with a .
-When the view is activated, all of ths installed packages are available for use in the environment.
+When the view is activated, all of the installed packages are available for use in the environment.
 
 !!! example "Activating the view"
     For an environment with `build-path=$SCRATCH/software/tool` that was built using `prgenv-gnu/25.6:v2`:

--- a/docs/build-install/uenv.md
+++ b/docs/build-install/uenv.md
@@ -24,10 +24,10 @@ export PATH=$PWD/uenv-spack:$PATH  # (2)!
 
 1. Download the `uenv-spack` tool from GitHub.
 
-2. Makes the `uenv-spack` executable available.
+2. Make the `uenv-spack` executable available.
 
 !!! note "Requires uv"
-    `uenv-spack` requires that [uv](https://docs.astral.sh/uv/) is installed to work.
+    `uenv-spack` requires [uv](https://docs.astral.sh/uv/).
     See our guide to setting up [installation locations][ref-guides-terminal-arch], before [installing uv](https://docs.astral.sh/uv/getting-started/installation).
 
 ### Select the uenv
@@ -68,7 +68,7 @@ uenv start prgenv-gnu/24.11:v1 --view=spack
     | `UENV_SPACK_URL`         | `https://github.com/spack/spack.git` | The git repository for Spack - nearly always the main spack/spack repository. |
     | `UENV_SPACK_COMMIT`      | `c6d4037758140fe...0cd1547f388ae51` | The commit of Spack that was used |
 
-    Spack version 1 moved the Spack packages from inside the Spack repository to a stand alone [repository on GitHub](https://github.com/spack/spack-packages).
+    Spack version 1 moved the Spack packages from inside the Spack repository to a standalone [repository on GitHub](https://github.com/spack/spack-packages).
     Uenvs that were built using Spack 1.0 and later will also set the following environment variables that provide information about the package versioning:
 
     | <div style="width:14em">variable</div> | <div style="width:16em">example</div> | description |
@@ -88,8 +88,8 @@ uenv start prgenv-gnu/24.11:v1 --view=spack
     It is strongly recommended that your version of Spack and the version of Spack in the uenv match when building software on top of an uenv.
 
 !!! note "Advanced Spack users"
-    The `uenv-spack` tool creates an empty Spack environment, configuration files and a build script that .
-    It is recommended that you take the time to the setup, and modify it as needed for your project.
+    The `uenv-spack` tool creates an empty Spack environment, configuration files and a build script that automates concretising and installing the environment.
+    It is recommended that you take the time to review the environment and configuration, and modify it as needed for your project.
 
     It is also possible to integrate uenv into your own Spack workflow.
     For this, it is recommended to load the `spack` view, and use the `UENV_SPACK_*` environment variables.
@@ -111,9 +111,11 @@ The `uenv-spack` tool can be used to create a build directory with a template [S
     ```bash
     uenv-spack <build-path> --uarch=<uarch> --name=<env-name>
     cd <build-path>
-    vim ./env/spack.yaml    # (1) !
+    vim ./env/spack.yaml    # (1)!
     ./build
     ```
+
+    1. Edit the [`spack.yaml`][Spack environment file] file to add package specs, set perferences, etc.
 
     All of the arguments are required:
 
@@ -239,7 +241,7 @@ The packages built by Spack are installed in `<build-path>/store`.
 
 ### Spack view
 
-A Spack view is generated in `<build-path>/view`, with a .
+A Spack view is generated in `<build-path>/view` with an activation script `<build-path>/view/activate.sh`.
 When the view is activated, all of the installed packages are available for use in the environment.
 
 !!! example "Activating the view"

--- a/docs/build-install/uenv.md
+++ b/docs/build-install/uenv.md
@@ -88,7 +88,7 @@ uenv start prgenv-gnu/24.11:v1 --view=spack
     It is strongly recommended that your version of Spack and the version of Spack in the uenv match when building software on top of an uenv.
 
 !!! note "Advanced Spack users"
-    The `uenv-spack` tool creates an empty Spack environment, configuration files and a build script that automates concretising and installing the environment.
+    The `uenv-spack` tool creates an empty Spack environment, configuration files and a build script that automates concretizing and installing the environment.
     It is recommended that you take the time to review the environment and configuration, and modify it as needed for your project.
 
     It is also possible to integrate uenv into your own Spack workflow.

--- a/docs/build-install/uenv.md
+++ b/docs/build-install/uenv.md
@@ -117,7 +117,7 @@ The `uenv-spack` tool can be used to create a build directory with a template [S
 
     1. Edit the [`spack.yaml`][Spack environment file] file to add package specs, set preferences, etc.
 
-    The argments to `uenv-spack` arguments are required:
+    The arguments to `uenv-spack` arguments are:
 
     * **required**: `<build-path>` is the path in which the environment will be built:
         * typically in `$SCRATCH`, e.g. `$SCRATCH/builds/gromacs-24.11`.

--- a/docs/build-install/uenv.md
+++ b/docs/build-install/uenv.md
@@ -117,17 +117,19 @@ The `uenv-spack` tool can be used to create a build directory with a template [S
 
     1. Edit the [`spack.yaml`][Spack environment file] file to add package specs, set preferences, etc.
 
-    All of the arguments are required:
+    The argments to `uenv-spack` arguments are required:
 
-    * `<build-path>` is the path in which the environment will be built:
+    * **required**: `<build-path>` is the path in which the environment will be built:
         * typically in `$SCRATCH`, e.g. `$SCRATCH/builds/gromacs-24.11`.
-    * `<uarch>`: is the microarchitecture:
+    * **required**: `--uarch=<uarch>`: is the microarchitecture:
         * one of `zen2, zen3, gh200, a100`;
         * used to set default variants in the Spack recipe.
-    * `<env-name>`: is the name of the environment:
+    * **required**: `--name=<env-name>`: is the name of the environment:
         * must start with a letter, and may only contain letters, numbers, underscores `_` and dashes `-`.
-
-
+    * **optional**: `--compiler=<compiler-name>`: is the compiler toolchain to use in the generated `spack.yaml`:
+        * one of `gcc`, `nvhpc`, `llvm`, or `llvm-amdgpu`.
+        * default: `gcc`
+        * note that the compiler must be in the list of compilers provided by the uenv.
 
 `uenv-spack` creates a directory tree with the following contents:
 


### PR DESCRIPTION
Update the uenv-spack docs to match the interface for the latest version of uenv-spack, which now supports uenv built using both Spack 1.0 and older Spack versions.

https://docs.tds.cscs.ch/314/build-install/uenv/#building-with-uenv