### PR TITLE
move extended images to pe; integrate them through links

### DIFF
--- a/docs/build-install/index.md
+++ b/docs/build-install/index.md
@@ -22,6 +22,8 @@ Modern HPC applications and software stacks are often very complicated, and ther
 
     And containers are used to deploy:
 
+    [:octicons-arrow-right-24: Alps Extended Images for ML][ref-software-extended-images]
+
     [:octicons-arrow-right-24: Cray Programming Environment][ref-cpe]
 
 </div>

--- a/docs/clusters/clariden.md
+++ b/docs/clusters/clariden.md
@@ -42,9 +42,9 @@ Users are encouraged to use containers on Clariden.
 
 * Jobs using containers can be easily set up and submitted using the [container engine][ref-container-engine].
 * To build images, see the [guide to building container images on Alps][ref-build-containers].
-* Base images which include the necessary libraries and compilers are for example available from the [Nvidia NGC Catalog](https://catalog.ngc.nvidia.com/containers):
-    * [HPC NGC container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvhpc)
-    * [PyTorch NGC container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch)
+* The [Nvidia NGC Catalog](https://catalog.ngc.nvidia.com/containers) provides containers with pre-built ML software stacks:
+    * **Recommended**: [Alps extended images][ref-software-extended-images] provided by CSCS are customized versions of NGC images optimized for the Alps network.
+    * Or start with base images from the [Nvidia NGC Catalog](https://catalog.ngc.nvidia.com/containers), for example the [HPC](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvhpc) and [PyTorch](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch) images --- note that you will have to use [container hooks][ref-ce-annotations] to get optimal network performance.
 
 Alternatively, [uenv][ref-uenv] are also available on Clariden. Currently deployed on Clariden:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -123,8 +123,6 @@ Learn by doing with our guides and tutorials.
 
     [:octicons-arrow-right-24: Container engine][ref-container-engine]
 
-    [:octicons-arrow-right-24: Alps extended images](software/alps-extended-images/index.md)
-
 
 -   :fontawesome-solid-screwdriver-wrench: __Data management and storage__
 

--- a/docs/software/alps-extended-images.md
+++ b/docs/software/alps-extended-images.md
@@ -1,12 +1,14 @@
+[](){#ref-software-extended-images}
 # Alps Extended Images
 
 The Alps infrastructure (specifically the networking stack) requires custom-built libraries and specific environment settings to fully leverage the high-speed network.
-To reduce the burden on users and ensure best-in-class performance, we provide pre-built **Alps Extended Images** based on popular container images (starting with those commonly used by the ML/AI community).
+To reduce the burden on users and ensure best-in-class performance, we provide pre-built **Alps Extended Images** based on popular container images, starting with those commonly used by the ML/AI community.
+
+!!! info
+    See our [communication library guide][ref-software-communication] for detailed information about how to build containers with optimised support for the Slingshot network used by Alps.
 
 !!! note
-
     All extended images are thoroughly tested and validated to ensure correct behavior and optimal performance (see [contributing section](#contributing)).
-
 
 ## Images
 
@@ -188,6 +190,7 @@ podman image inspect "$IMAGE" --format 'Source Revision: {{ index .Labels "org.o
 podman image inspect "$IMAGE" --format 'Build Time: {{ index .Labels "org.opencontainers.image.created" }}'
 ```
 
+[](){#ref-software-extended-images-contributing}
 ## Contributing
 
 The Alps extended images are automatically built via a dedicated CI/CD pipeline hosted on GitHub:

--- a/docs/software/ml/index.md
+++ b/docs/software/ml/index.md
@@ -27,7 +27,9 @@ For detailed information on storage options and best practices for managing data
 
 Containerization is the recommended approach for ML workloads on Alps, as it simplifies software management and maximizes compatibility with other systems.
 
-Users are encouraged to build their own containers, starting from popular sources such as the [Nvidia NGC Catalog](https://catalog.ngc.nvidia.com/containers), which offers a variety of pre-built images optimized for HPC and ML workloads.
+The recommended container to use as the base for your work are the [Alps extended images][ref-software-extended-images] --- [Nvidia NGC](https://catalog.ngc.nvidia.com/containers) containers that have been fine-tuned and extended for best performance on Alps.
+
+Alternatively users can build their own images starting from popular sources such as the [Nvidia NGC Catalog](https://catalog.ngc.nvidia.com/containers), which offers a variety of pre-built images optimized for HPC and ML workloads.
 Examples include:
 
 * [PyTorch NGC container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch) ([Release Notes](https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/index.html))

--- a/docs/software/prgenv/index.md
+++ b/docs/software/prgenv/index.md
@@ -1,7 +1,14 @@
 [](){#ref-software-prgenvs}
 # Programming Environments
 
-CSCS provides "programming environments" on Alps vClusters that provide compilers, MPI, and commonly used libraries and packages, that can be used to build applications from source.
+CSCS provides "programming environments" on Alps clusters.
+Programming environments provide pre-installed software, libraries and tools that can be used to build or install applications and workflows.
+For example:
+
+- The `prgenv` uenv provide provide compilers, MPI, and commonly-used libraries and packages for building applications from source.
+- Container images for ML/AI with optimised communication and GPU libraries and popular frameworks like PyTorch, on top of which workflow-specific tools can be installed.
+
+## Uenv
 
 <div class="grid cards" markdown>
 
@@ -26,6 +33,17 @@ CSCS provides "programming environments" on Alps vClusters that provide compiler
 
     Provides a complete HPC setup for running Julia efficiently at scale, using the supercomputer hardware optimally.
 
+</div>
+
+## Containers
+
+<div class="grid cards" markdown>
+
+-   :fontawesome-solid-layer-group: [__Alps Extended Images__][ref-software-extended-images] containers
+
+    Container images based on [NGC]() images that have been fine-tuned for Alps.
+    Recommended as the starting point for ML/AI workflows.
+
 -   :fontawesome-solid-layer-group: [__Cray Programming Environment__][ref-cpe] containers
 
     The Cray Programming Environment (CPE) is a suite of compilers, libraries and tools provided by HPE.
@@ -33,4 +51,3 @@ CSCS provides "programming environments" on Alps vClusters that provide compiler
     These are the "Cray Modules", familiar to users of old Piz Daint and other HPE/Cray clusters.
 
 </div>
-

--- a/docs/software/prgenv/index.md
+++ b/docs/software/prgenv/index.md
@@ -41,7 +41,7 @@ For example:
 
 -   :fontawesome-solid-layer-group: [__Alps Extended Images__][ref-software-extended-images] containers
 
-    Container images based on [NGC]() images that have been fine-tuned for Alps.
+    Container images based on [NGC](https://catalog.ngc.nvidia.com/) that have been fine-tuned for Alps.
     Recommended as the starting point for ML/AI workflows.
 
 -   :fontawesome-solid-layer-group: [__Cray Programming Environment__][ref-cpe] containers

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,7 +70,6 @@ nav:
       - 'Hooks and native resources': software/container-engine/resource-hook.md
       - 'EDF reference': software/container-engine/edf.md
       - 'Known issues': software/container-engine/known-issue.md
-    - 'Alps Extended Images' : software/alps-extended-images/index.md
   - 'Building and Installing Software':
     - build-install/index.md
     - 'Programming Environments':
@@ -81,6 +80,7 @@ nav:
       - 'linalg': software/prgenv/linalg.md
       - 'julia': software/prgenv/julia.md
       - 'Cray modules (CPE)': software/prgenv/cpe.md
+      - 'Alps Extended Images' : software/alps-extended-images.md
     - 'How to build software':
       - 'uenv': build-install/uenv.md
       - 'Python': build-install/python.md


### PR DESCRIPTION
Move the Alps extended images docs out of the uenv/ce tool docs, and into programming environments.

Add lots of links from the Clariden, ML software, and other pages to these docs.

Update references to NGC to recommend the extended images.