### PR TITLE
Update scratch cleanup policy with per-filesystem retention periods

### DIFF
--- a/docs/platforms/cwp/index.md
+++ b/docs/platforms/cwp/index.md
@@ -49,7 +49,7 @@ See the [Scratch][ref-storage-scratch] documentation for more information.
 The environment variable `SCRATCH=/capstor/scratch/cscs/$USER` is set automatically when you log into the system, and can be used as a shortcut to access scratch.
 
 !!! warning "scratch cleanup policy"
-    Files that have not been accessed in 30 days are automatically deleted.
+    Files that have not been accessed in **30 days** are automatically deleted.
 
     **Scratch is not intended for permanent storage**: transfer files back to the [Store][ref-storage-store] after job runs.
 

--- a/docs/platforms/hpcp/index.md
+++ b/docs/platforms/hpcp/index.md
@@ -56,7 +56,7 @@ See the [Scratch][ref-storage-scratch] documentation for more information.
 The environment variable `$SCRATCH` points to `/capstor/scratch/cscs/$USER`, and can be used as a shortcut to access your scratch folder.
 
 !!! warning "scratch cleanup policy"
-    Files that have not been accessed in 30 days are automatically deleted.
+    Files that have not been accessed in **30 days** are automatically deleted.
 
     **Scratch is not intended for permanent storage**: transfer files back to the [Store][ref-storage-store] after batch job completion.
 

--- a/docs/platforms/mlp/index.md
+++ b/docs/platforms/mlp/index.md
@@ -66,7 +66,8 @@ Scratch is per user - each user gets separate scratch path and quota.
 * There is an additional scratch path mounted on [Capstor][ref-alps-capstor] at `/capstor/scratch/cscs/$USER`.
 
 !!! warning "scratch cleanup policy"
-    Files that have not been accessed in 30 days are automatically deleted.
+    - Files on `/iopsstor/scratch/cscs/$USER` that have not been accessed in **21 days** are automatically deleted.
+    - Files on `/capstor/scratch/cscs/$USER` that have not been accessed in **30 days** are automatically deleted.
 
     **Scratch is not intended for permanent storage**: transfer files back to the capstor project storage after job runs.
 

--- a/docs/storage/filesystems.md
+++ b/docs/storage/filesystems.md
@@ -105,7 +105,7 @@ The [cleanup policy][ref-storage-cleanup] is enforced on Scratch, to ensure cont
 !!! warning "Hidden directories are excluded from the cleaning policy"
     The following directories are automatically created by the system and are **not** subject to the cleaning policy. They will never be automatically deleted:
 
-    - `.uenv-images`: user environments downloaded from JFrog
+    - `.uenv-images`: used by [uenv][ref-uenv] as the default repository for [managing uenv images][ref-uenv-manage].
     - `.enroot`: container images downloaded by the user
     - `.edf_imagestore`: container images used by the Container Engine
 

--- a/docs/storage/filesystems.md
+++ b/docs/storage/filesystems.md
@@ -109,6 +109,8 @@ The [cleanup policy][ref-storage-cleanup] is enforced on Scratch, to ensure cont
     - `.enroot`: container images downloaded by the user
     - `.edf_imagestore`: container images used by the Container Engine
 
+    Using these directories to store general data in order to circumvent the cleaning policy is a violation of CSCS usage policies.
+
     These directories can consume significant disk space and inodes over time.
     If you no longer need the environments or containers stored there, you can safely remove them manually to free up space.
 

--- a/docs/storage/filesystems.md
+++ b/docs/storage/filesystems.md
@@ -96,10 +96,21 @@ All users on Alps get their own Scratch path, `/capstor/scratch/cscs/$USER`, whi
 
 The [cleanup policy][ref-storage-cleanup] is enforced on Scratch, to ensure continued performance of the file system.
 
-* Files not accessed in the last 30 days are automatically deleted.
+* Files on `/capstor/scratch/cscs/$USER` that have not been accessed in **30 days** are automatically deleted.
+* Files on `/iopsstor/scratch/cscs/$USER` that have not been accessed in **21 days** are automatically deleted.
 * When capacity grows above:
     * 60%: users are asked to start removing or archiving unneeded files
     * 80%: CSCS will start removing files and paths without further notice.
+
+!!! warning "Hidden directories are excluded from the cleaning policy"
+    The following directories are automatically created by the system and are **not** subject to the cleaning policy. They will never be automatically deleted:
+
+    - `.uenv-images`: user environments downloaded from JFrog
+    - `.enroot`: container images downloaded by the user
+    - `.edf_imagestore`: container images used by the Container Engine
+
+    These directories can consume significant disk space and inodes over time.
+    If you no longer need the environments or containers stored there, you can safely remove them manually to free up space.
 
 ### Quota
 
@@ -303,7 +314,10 @@ Ideally occupancy should not exceed 60%, with severe performance degradation for
 
 File cleanup removes files that are not being used to ensure that occupancy and file counts do not affect file system performance.
 
-A daily process removes files that have not been **accessed (either read or written)** in the last 30 days.
+A daily process removes files that have not been **accessed (either read or written)** within the retention period:
+
+* **30 days** on [Capstor][ref-alps-capstor] (`/capstor/scratch/cscs/$USER`)
+* **21 days** on [Iopsstor][ref-alps-iopsstor] (`/iopsstor/scratch/cscs/$USER`)
 
 ??? example "How can I tell when a file was last accessed?"
     The access time of a file can be found using the `stat` command.

--- a/docs/storage/filesystems.md
+++ b/docs/storage/filesystems.md
@@ -107,7 +107,7 @@ The [cleanup policy][ref-storage-cleanup] is enforced on Scratch, to ensure cont
 
     - `.uenv-images`: used by [uenv][ref-uenv] as the default repository for [managing uenv images][ref-uenv-manage].
     - `.enroot`: container images downloaded by the user
-    - `.edf_imagestore`: container images used by the Container Engine
+    - `.edf_imagestore`: container images used by the [Container Engine][ref-container-engine]
 
     Using these directories to store general data in order to circumvent the cleaning policy is a violation of CSCS usage policies.
 


### PR DESCRIPTION
 ## Summary

  - Differentiate cleanup retention periods between Capstor (30 days) and Iopsstor (21 days)
  - Add warning about hidden directories (`.uenv-images`, `.enroot`, `.edf_imagestore`) excluded from the cleaning policy
  - Update platform pages (MLP, HPCP, CWP) to reflect the correct retention periods

## Changed files

  - `docs/storage/filesystems.md`: updated Scratch and Cleanup policies sections
  - `docs/platforms/mlp/index.md`: split cleanup policy into Iopsstor (21 days) and Capstor (30 days)
  - `docs/platforms/hpcp/index.md`: minor formatting (bold on retention period)
  - `docs/platforms/cwp/index.md`: minor formatting (bold on retention period)