### PR TITLE
delete misleading and now incorrect information

### DIFF
--- a/docs/running/slurm.md
+++ b/docs/running/slurm.md
@@ -31,7 +31,6 @@ Refer to the [Quick Start User Guide](https://slurm.schedmd.com/quickstart.html)
 
 Slurm associates each job with a CSCS project in order to perform accounting.
 The project to use for accounting is specified using the `--account/-A` flag.
-If no job is specified, the primary project is used as the default.
 
 ??? example "Which projects am I a member of?"
     Users often are part of multiple projects, and by extension their associated `groupd_id` groups.


### PR DESCRIPTION
the sentence mentions `job`, while it should be project or accounting.
Also the information is not true for any big cluster. `-A` is always mandatory.