### PR TITLE
Strip prompts when copying code snippets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,7 +271,10 @@ Recent entries are expanded, older ones are folded:
 
 ### Code blocks
 
-Use `console` for interactive shell sessions that show a prompt and output:
+Use a session lexer for interactive shell sessions with prompt-output pairs:
+
+- `console` for bash/zsh, with `$` as the prompt character
+- `pwsh-session` for PowerShell, with `PS>` as the prompt character
 
 ```
 ```console title="check the queue"
@@ -279,7 +282,9 @@ $ squeue --me
 ```
 ```
 
-Use `bash` for command-only blocks that should be easy to copy (no prompt, no output):
+Prompts and command output are stripped from the copy button, so include realistic output where it helps the reader.
+
+Use `bash` (or `powershell` for PowerShell) for command-only blocks (no prompt, no output):
 
 ```
 ```bash title="load a uenv"
@@ -288,7 +293,7 @@ uenv start prgenv-gnu/24.11:v1
 ```
 
 `terminal` is **not** a valid lexer — MkDocs will silently render it without highlighting.
-Always use `$` as the prompt character in `console` blocks; `>` is not highlighted correctly.
+In `console` blocks, use `$` as the prompt character; `>` is not highlighted correctly.
 Add a `title=` to every code block to describe what it does.
 
 ### Reusing content with snippets

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,7 +284,8 @@ $ squeue --me
 
 Prompts and command output are stripped from the copy button, so include realistic output where it helps the reader.
 
-Use `bash` (or `powershell` for PowerShell) for command-only blocks (no prompt, no output):
+Use `bash` for command-only blocks (no prompt, no output).
+Use `powershell` for the PowerShell equivalent.
 
 ```
 ```bash title="load a uenv"

--- a/docs/access/ssh.md
+++ b/docs/access/ssh.md
@@ -59,14 +59,14 @@ On Windows, choose the PowerShell tab for the native binary, or the Linux tab wh
     ```
 
 === "Windows (x86_64, PowerShell)"
-    ```powershell title="install cscs-key on Windows"
-    > $TAG = "v1.1.0"
-    > mkdir $HOME\bin -Force
-    > cd $HOME\bin
-    > curl.exe -LO "https://github.com/eth-cscs/cscs-key/releases/download/$TAG/cscs-key-$TAG-x86_64-pc-windows-msvc.zip"
-    > Expand-Archive -Path "cscs-key-$TAG-x86_64-pc-windows-msvc.zip" -DestinationPath .
-    > Remove-Item "cscs-key-$TAG-x86_64-pc-windows-msvc.zip"
-    > cscs-key --version
+    ```pwsh-session title="install cscs-key on Windows"
+    PS> $TAG = "v1.1.0"
+    PS> mkdir $HOME\bin -Force
+    PS> cd $HOME\bin
+    PS> curl.exe -LO "https://github.com/eth-cscs/cscs-key/releases/download/$TAG/cscs-key-$TAG-x86_64-pc-windows-msvc.zip"
+    PS> Expand-Archive -Path "cscs-key-$TAG-x86_64-pc-windows-msvc.zip" -DestinationPath .
+    PS> Remove-Item "cscs-key-$TAG-x86_64-pc-windows-msvc.zip"
+    PS> cscs-key --version
     cscs-key 1.1.0
     ```
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -462,7 +462,10 @@ Use [code blocks](https://squidfunk.github.io/mkdocs-material/reference/code-blo
 The documentation uses [pygments](https://pygments.org) for highlighting.
 See [list of available lexers](https://pygments.org/docs/lexers/#) for the languages that you can use for code blocks.
 
-Use [`console`](https://pygments.org/docs/lexers/#pygments.lexers.shell.BashSessionLexer) for interactive sessions with prompt-output pairs:
+Use a session lexer for interactive sessions with prompt-output pairs:
+
+* [`console`](https://pygments.org/docs/lexers/#pygments.lexers.shell.BashSessionLexer) for bash/zsh, with `$` as the prompt character
+* [`pwsh-session`](https://pygments.org/docs/lexers/#pygments.lexers.shell.PowerShellSessionLexer) for PowerShell, with `PS>` as the prompt character
 
 === "Markdown"
 
@@ -480,20 +483,23 @@ Use [`console`](https://pygments.org/docs/lexers/#pygments.lexers.shell.BashSess
     Hello, world!
     ```
 
+!!! tip "Prompts and output are stripped from the copy button"
+    Users who click "copy" get just the runnable commands, so feel free to include realistic prompts and output.
+
 !!! warning
     `terminal` is not a valid lexer, but MkDocs or pygments will not warn about using it as a language.
     The text will be rendered without highlighting.
 
 !!! warning
-    Use `$` as the prompt character, optionally preceded by text.
-    `>` as the prompt character will not be highlighted correctly.
+    In `console` blocks, use `$` as the prompt character.
+    `>` will not be highlighted correctly as a prompt.
 
 Note the use of `title=...`, which will give the code block a heading.
 
 !!! tip
     Include a title whenever possible to describe what the code block does or is.
 
-If you want to display commands without output that can easily be copied, use `bash` as the language:
+For command-only blocks (no prompt, no output), use `bash`:
 
 === "Markdown"
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -460,12 +460,18 @@ As a placeholder for documentation that needs to be written.
 
 Use [code blocks](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/) when you want to display monospace text in a programming language, terminal output, configuration files etc.
 The documentation uses [pygments](https://pygments.org) for highlighting.
-See [list of available lexers](https://pygments.org/docs/lexers/#) for the languages that you can use for code blocks.
+The language of a code block is set by its *lexer* — the name written after the opening triple backticks.
+See the [list of available lexers](https://pygments.org/docs/lexers/#).
 
-Use a session lexer for interactive sessions with prompt-output pairs:
+Use `title=...` whenever possible to give the block a descriptive heading, as shown in the examples below.
 
-* [`console`](https://pygments.org/docs/lexers/#pygments.lexers.shell.BashSessionLexer) for bash/zsh, with `$` as the prompt character
-* [`pwsh-session`](https://pygments.org/docs/lexers/#pygments.lexers.shell.PowerShellSessionLexer) for PowerShell, with `PS>` as the prompt character
+For an interactive shell session that shows both the commands you type and the output they produce, use:
+
+* [`console`](https://pygments.org/docs/lexers/#pygments.lexers.shell.BashSessionLexer) for bash/zsh — write the prompt as `$`
+* [`pwsh-session`](https://pygments.org/docs/lexers/#pygments.lexers.shell.PowerShellSessionLexer) for PowerShell — write the prompt as `PS>`
+
+These lexers highlight prompts, commands and output.
+They also let the copy button strip prompts and output, so only the runnable commands are copied.
 
 === "Markdown"
 
@@ -483,23 +489,11 @@ Use a session lexer for interactive sessions with prompt-output pairs:
     Hello, world!
     ```
 
-!!! tip "Prompts and output are stripped from the copy button"
-    Users who click "copy" get just the runnable commands, so feel free to include realistic prompts and output.
-
 !!! warning
-    `terminal` is not a valid lexer, but MkDocs or pygments will not warn about using it as a language.
+    `terminal` is not a valid lexer, but neither MkDocs nor pygments will warn you.
     The text will be rendered without highlighting.
 
-!!! warning
-    In `console` blocks, use `$` as the prompt character.
-    `>` will not be highlighted correctly as a prompt.
-
-Note the use of `title=...`, which will give the code block a heading.
-
-!!! tip
-    Include a title whenever possible to describe what the code block does or is.
-
-For command-only blocks (no prompt, no output), use `bash`:
+For command-only blocks (no prompt, no output), use [`bash`](https://pygments.org/docs/lexers/#pygments.lexers.shell.BashLexer) or [`powershell`](https://pygments.org/docs/lexers/#pygments.lexers.shell.PowerShellLexer):
 
 === "Markdown"
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -146,3 +146,14 @@
   border-radius: 2px;
 }
 
+/* In `console` code blocks, exclude the shell prompt (`$`) and command */
+/* output from the copy button, so users get just the commands. */
+/* Material's copy button reads `innerText` after briefly setting */
+/* `data-md-copying` on the code element, and `innerText` ignores */
+/* hidden content. Selection is left alone so users can still grab the */
+/* full transcript by hand. */
+[data-md-copying] .gp,
+[data-md-copying] .go {
+  display: none;
+}
+

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -146,12 +146,9 @@
   border-radius: 2px;
 }
 
-/* In `console` code blocks, exclude the shell prompt (`$`) and command */
-/* output from the copy button, so users get just the commands. */
-/* Material's copy button reads `innerText` after briefly setting */
-/* `data-md-copying` on the code element, and `innerText` ignores */
-/* hidden content. Selection is left alone so users can still grab the */
-/* full transcript by hand. */
+/* Strip prompts (.gp) and output (.go) from the copy button in session
+   code blocks (console, pwsh-session). Material toggles data-md-copying
+   only during the copy click, so manual selection still gets everything. */
 [data-md-copying] .gp,
 [data-md-copying] .go {
   display: none;


### PR DESCRIPTION
The copy button in top-right of the code snippet copies only the code without the command line prompt '$' and the command output.

Closes eth-cscs/cscs-key#6