### PR TITLE
Update lammps.md

### DIFF
--- a/docs/software/sciapps/lammps.md
+++ b/docs/software/sciapps/lammps.md
@@ -395,6 +395,16 @@ lmp ...
     pip install mace-torch cuequivariance-torch cuequivariance cuequivariance-ops-torch-cu12 cupy-cuda12x
     ```
 
+    !!! warning "`triton`"
+
+        If you are using a (custom) uenv where PyTorch is provided by the uenv itself,
+        make sure `triton` is installed in the venv,
+        otherwise `cuequivariance_ops_torch` can't be imported leading to poor performance.
+
+        ```bash
+        pip install triton
+        ```
+
     Convert your MACE model to LAMMPS format using the provided conversion script:
 
     ```bash


### PR DESCRIPTION
The official LAMMPS uenv does not provide Pytorch and suggest to install it manually, but `lammps+plumed ^plumed+pytorch` requires `plumed` to be compiled against `libtorch` so PyTorch needs to be provided by the uenv. It's an edge case, but adding the warning to make sure `triton` is available doesn't hurt.