### PR TITLE
Update inference docs with claude/opencode information and internal service

### DIFF
--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -205,3 +205,10 @@ Once connected, you can choose models configured in the config.
 * Detailed self-service telemetry is limited today.
 * Documentation and model-specific configuration transparency are work in progress.
 * Load balancing and other QoS need to be understood.
+
+
+## CSCS-internal inference service
+
+For CSCS staff, an internal inference service is available on CSCS VPN through the https://ai-gateway.svc.cscs.ch URL.
+Usage is otherwise identical to the https://llm-proxy.svc.cscs.ch endpoint.
+For more information and keys, join the #cscs-inference-services Slack channel.

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -58,37 +58,60 @@ However, CSCS collects infrastructure metrics and telemetry, including prompt an
 [](){#ref-inference-api-quickstart}
 ## Quick Start
 
-Before using the API, obtain an authentication token by following the [access guide][ref-inference-api-access]. Include this token in every API request.
+Before using the API, obtain an authentication token by following the [access guide][ref-inference-api-access].
+Include this token in every API request.
 
-!!! example "Anthropic's `claude`"
-    Example environment configuration to be set before starting a `claude` session.
-    ```console
-    $ export ANTHROPIC_API_KEY=<AUTHENTICATION_TOKEN>
-    $ export ANTHROPIC_BASE_URL=https://llm-proxy.svc.cscs.ch/v1
-    $ export ANTHROPIC_MODEL=Apertus-70B-Instruct-2509
-    $ claude
-    ```
+Query available models using the `/models` endpoint:
+```bash
+curl -X GET "https://llm-proxy.svc.cscs.ch/v1/models" \
+  -H "Authorization: Bearer <AUTHENTICATION_TOKEN>" \
+  -H "Content-Type: application/json"
+```
 
-!!! example "List available models"
-    ```console
-    $ curl -X GET "https://llm-proxy.svc.cscs.ch/v1/models" \
-      -H "Authorization: Bearer <AUTHENTICATION_TOKEN>" \
-      -H "Content-Type: application/json"
-    ```
-
-!!! example "Chat completion request"
-    ```console
-    $ curl -X POST "https://llm-proxy.svc.cscs.ch/chat/completions" \
-      -H "Authorization: Bearer <AUTHENTICATION_TOKEN>" \
-      -H "Content-Type: application/json" \
-      -d '{
-        "model": "Apertus-70B-Instruct-2509",
-        "messages": [
-          {"role": "user", "content": "Explain gradient descent in one paragraph."}
-        ],
-        "temperature": 0.2
-      }'
-    ```
+To get a response using the Apertus 70B model do (piped into `jq` for pretty output):
+```console
+$ curl -X POST "https://llm-proxy.svc.cscs.ch/chat/completions" \
+    -H "Authorization: Bearer <AUTHENTICATION_TOKEN>" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "Apertus-70B-Instruct-2509",
+      "messages": [
+        {"role": "user", "content": "Explain gradient descent in one paragraph."}
+      ],
+      "temperature": 0.2
+    }' | jq
+{
+  "id": "chatcmpl-f11032007bc340a88db62b46fac1224a",
+  "created": 1780997039,
+  "model": "Apertus-70B-Instruct-2509",
+  "object": "chat.completion",
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "content": "Gradient descent is an optimization algorithm used in machine learning to minimize the cost function of a model. It works by iteratively adjusting the model's parameters in the direction of steepest descent of the cost fu
+nction. This is done by calculating the gradient of the cost function with respect to each parameter, which gives the direction of the steepest increase. The algorithm then takes a step in the opposite direction of this gradient, effectively
+ moving downhill on the cost function landscape. The size of the step, or the learning rate, determines how quickly the algorithm converges to the minimum. The process is repeated until the algorithm converges to a minimum, which ideally cor
+responds to the optimal set of parameters for the model. Gradient descent is a fundamental concept in deep learning and is used in various variants such as stochastic gradient descent, mini-batch gradient descent, and more.",
+        "role": "assistant",
+        "provider_specific_fields": {
+          "refusal": null
+        }
+      },
+      "provider_specific_fields": {
+        "token_ids": null,
+        "stop_reason": null
+      }
+    }
+  ],
+  "usage": {
+    "completion_tokens": 169,
+    "prompt_tokens": 69,
+    "total_tokens": 238
+  }
+}
+```
 
 [](){#ref-inference-api-access}
 ## Access
@@ -121,6 +144,54 @@ The service is accessed through the gateway base URL `https://llm-proxy.svc.cscs
 
 [](){#ref-inference-api-guides}
 ## Guides
+
+### Setting up coding agents to use the inference service
+
+Below are instructions for setting up [Claude Code](https://claude.com/product/claude-code) and [OpenCode](https://opencode.ai).
+For more details and for other agents, see their respective documentation pages.
+
+#### Claude Code
+
+Set the following environment variables before starting a `claude` session.
+
+```bash
+export ANTHROPIC_API_KEY=<AUTHENTICATION_TOKEN>
+export ANTHROPIC_BASE_URL=https://llm-proxy.svc.cscs.ch/v1
+export ANTHROPIC_MODEL=Apertus-70B-Instruct-2509
+claude
+```
+
+#### OpenCode
+
+Add a custom provider to your OpenCode config file (typically `~/.config/opencode/opencode.json`).
+
+```json title="configure opencode for the cscs llm inference api"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "cscs": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "CSCS Inference",
+      "options": {
+        "baseURL": "https://llm-proxy.svc.cscs.ch/v1"
+      },
+      "models": {
+        "Apertus-70B-Instruct-2509": {
+          "name": "Apertus 70B"
+        }
+      }
+    }
+  }
+}
+```
+
+Start OpenCode and run the `/connect` command.
+Select "CSCS Inference" to choose the newly added provider, and enter your API key when prompted.
+Once connected, you can choose models configured in the config.
+
+!!! info
+    OpenCode does not auto-discover available models.
+    Models have to be explicitly configured in the config.
 
 ### Reducing consumption
 

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -150,6 +150,14 @@ The service is accessed through the gateway base URL `https://llm-proxy.svc.cscs
 Below are instructions for setting up [Claude Code](https://claude.com/product/claude-code) and [OpenCode](https://opencode.ai).
 For more details and for other agents, see their respective documentation pages.
 
+!!! info
+    Both agent frameworks can be launched inside a loaded [uenv][ref-uenv] or [container][ref-container-engine], which will allow the agents to build and run your project.
+
+!!! warning
+    The agents will have access to to your files and are able to submit jobs on behalf of you.
+    This has to be handled very carefully; as a user you are responsible for the actions of the agents that you launch.
+    Compute resources used by agent-launched Slurm jobs will be billed towards your project account.
+
 #### Claude Code
 
 Set the following environment variables before starting a `claude` session.


### PR DESCRIPTION
Moves the claude code section to a separate coding agent section. Adds instructions on setting up opencode.

Also adds a note on the internal inference service at the bottom of the inference page.