### PR TITLE
clariden: document debug and low partition configuration

### DIFF
--- a/docs/clusters/clariden.md
+++ b/docs/clusters/clariden.md
@@ -82,9 +82,9 @@ There are four Slurm partitions on the system:
 
 | name | nodes  | max nodes per job | time limit |
 | --   | --     | --                | -- |
-| `normal` | 1204       | -    | 12 hours |
-| `debug`  | 1204 (shared with `normal`) | 4 | 1.5 node-hours |
-| `low`    | 1204 (shared with `normal`) | -    | 24 hours |
+| `normal` | most nodes | -    | 12 hours |
+| `debug`  | most nodes (shared with `normal`) plus a few dedicated | 4 | 1.5 node-hours |
+| `low`    | most nodes (shared with `normal`) | -    | 24 hours |
 | `xfer`   | 2          | 1    | 24 hours |
 
 * jobs in the `normal`, `debug`, and `low` partitions get exclusive use of their allocated nodes (one job per node)

--- a/docs/clusters/clariden.md
+++ b/docs/clusters/clariden.md
@@ -73,21 +73,33 @@ For detailed instructions and best practices with ML frameworks, please refer to
 
 Clariden uses [Slurm][ref-slurm] as the workload manager, which is used to launch and monitor distributed workloads, such as training runs.
 
-There are two Slurm partitions on the system:
+There are four Slurm partitions on the system:
 
 * the `normal` partition is for all production workloads.
-* the `debug` partition can be used to access a small allocation for up to 30 minutes for debugging and testing purposes.
+* the `debug` partition is intended for short debugging and testing jobs. It is configured on top of the same node pool as `normal`, with tight per-user limits to keep it focused on its intended use case.
+* the `low` partition is a low-priority partition, which may be enabled for specific projects at specific times.
 * the `xfer` partition is for [internal data transfer][ref-data-xfer-internal] at CSCS.
 
 | name | nodes  | max nodes per job | time limit |
 | --   | --     | --                | -- |
 | `normal` | 1204       | -    | 12 hours |
-| `debug`  | 24         | 2    | 1.5 node-hours |
+| `debug`  | 1204 (shared with `normal`) | 4 | 1.5 node-hours |
+| `low`    | 1204 (shared with `normal`) | -    | 24 hours |
 | `xfer`   | 2          | 1    | 24 hours |
 
-* nodes in the `normal` and `debug` partitions are not shared
+* jobs in the `normal`, `debug`, and `low` partitions get exclusive use of their allocated nodes (one job per node)
+* the `low` partition shares the exact same node pool as `normal`, while `debug` shares that pool *and* adds a small set of nodes dedicated to debugging: short debug jobs therefore always have capacity available, even when `normal` is full
+* because these partitions overlap, a node may belong to more than one of them at the same time
 * nodes in the `xfer` partition can be shared
 * nodes in the `debug` queue have a 1.5 node-hour time limit. This means you could for example request 2 nodes for 45 minutes each, or 1 single node for the full time limit.
+
+The `debug` partition has additional per-user limits enforced by its QoS:
+
+* max 1 running job per user
+* max 2 submitted jobs per user (1 running + 1 pending)
+* max 90 node·minutes per job (e.g. 1 node × 90 min, 2 nodes × 45 min, or 4 nodes × 22 min)
+
+The `debug` partition is scheduled at a higher priority than `normal`, so debug jobs are placed ahead of `normal` jobs in the queue and typically start sooner. Preemption is disabled, so debug jobs never interrupt running `normal` jobs: they simply use idle nodes as soon as these become available. The tight per-user limits make the partition unsuitable for production workloads while keeping it responsive for short debug sessions.
 
 See the Slurm documentation for instructions on how to run jobs on the [Grace-Hopper nodes][ref-slurm-gh200].
 
@@ -96,9 +108,10 @@ See the Slurm documentation for instructions on how to run jobs on the [Grace-Ho
     ```console
     $ sinfo --format "| %20R | %10D | %10s | %10l | %10A |"
     | PARTITION            | NODES      | JOB_SIZE   | TIMELIMIT  | NODES(A/I) |
-    | debug                | 32         | 1-2        | 30:00      | 3/29       |
-    | normal               | 1266       | 1-infinite | 1-00:00:00 | 812/371    |
-    | xfer                 | 2          | 1          | 1-00:00:00 | 1/1        |
+    | debug                | 1384       | 1-4        | 1:30:00    | 1260/82    |
+    | normal               | 1359       | 1-infinite | 12:00:00   | 1254/65    |
+    | low                  | 1359       | 1-infinite | 1-00:00:00 | 1254/65    |
+    | xfer                 | 2          | 1          | 1-00:00:00 | 2/0        |
     ```
     The last column shows the number of nodes that have been allocated in currently running jobs (`A`) and the number of jobs that are idle (`I`).
 


### PR DESCRIPTION
  Updates the Slurm partition documentation for Clariden to reflect the current configuration:

  - `debug` now shares the `normal` node pool plus a small set of dedicated nodes (previously 24 dedicated nodes), with `max
  nodes per job` raised to 4
  - document the per-user QoS limits on `debug` (1 running job, 2 submitted, 90 node·minutes per job)
  - correct the scheduling priority: `debug` runs at a higher priority tier than `normal` (jobs start sooner) but with
  preemption disabled
  - document the `low` low-priority partition, consistent with daint/eiger
  - use qualitative node counts ("most nodes") instead of exact numbers that quickly go stale, and refresh the `sinfo` example
  output