### PR TITLE
Update Homebrew installation command for cscs-key

### DIFF
--- a/docs/access/ssh.md
+++ b/docs/access/ssh.md
@@ -28,8 +28,7 @@ On Windows, choose the PowerShell tab for the native binary, or the Linux tab wh
 
 === "Homebrew (macOS, Linux)"
     ```console title="install cscs-key from Homebrew"
-    $ brew tap eth-cscs/tap
-    $ brew install cscs-key
+    $ brew install eth-cscs/tap/cscs-key
     $ cscs-key --version
     cscs-key 1.1.0
     ```


### PR DESCRIPTION
Recent Homebrew releases (5.1.15+) have introduced tap trust (https://docs.brew.sh/Tap-Trust).

This requires third-party formulae to be referenced by their fully qualified path (`<user>/<tap>/<formula>`), and will enforce this by default in 5.2.0 / 6.0.0, unless trust is manually enabled for that specific formula or the whole tap.

See e.g. ddev/ddev#8450.