### PR TITLE
CE: AWS OFI NCCL update

### DIFF
--- a/docs/software/communication/nccl.md
+++ b/docs/software/communication/nccl.md
@@ -56,18 +56,18 @@ To use NCCL in a container, enable the [AWS OFI hook][ref-ce-aws-ofi-hook] in th
 
 ```toml
 [env]
-PMIX_MCA_psec="native" # (1)!
+PMIX_MCA_psec="^munge" # (1)!
 
 [annotations]
 com.hooks.aws_ofi_nccl.enabled = "true"    # (2)!
-com.hooks.aws_ofi_nccl.variant = "cuda12"  # (3)!
+com.hooks.aws_ofi_nccl.variant = "cuda-dl"  # (3)!
 ```
 
-1. Ensures PMIx uses the same security domain as Slurm. Otherwise PMIx will print warnings at startup.
+1. Ensures PMIx does not use the Munge security domain, which is not exposed into containers. Otherwise PMIx will print warnings at startup.
 2. Enable the AWS OFI plugin.
-3. Take care to match the major CUDA version installed in the container.
+3. The dynamically-linked (`dl`) variant is generally recommended for portability across CUDA versions. Statically linked variants must match the major CUDA version installed in the container. More details [here][ref-ce-aws-ofi-hook].
 
-Because NCCL uses OpenMPI in the container to perform initial setup, which in turn uses [PMIx](https://pmix.org/) for wire-up, pass the `--mpi=pmix` option to `srun` when launching jobs.
+Because the NCCL Tests use OpenMPI in the container to perform initial setup, which in turn uses [PMIx](https://pmix.org/) for wire-up, pass the `--mpi=pmix` option to `srun` when launching jobs.
 
 ```console
 $ srun --mpi=pmix -n8 -N2 --environment=nccl-test /nccl-tests-2.17.1/build/all_reduce_perf

--- a/docs/software/container-engine/known-issue.md
+++ b/docs/software/container-engine/known-issue.md
@@ -117,7 +117,7 @@ When using the `cuda-dl` variant of the [AWS OFI NCCL hook][ref-ce-aws-ofi-hook]
 Dynamic linking makes the plugin interoperable across CUDA versions, but also reliant on a non-versioned symlink to the CUDA Runtime Library (e.g. `/usr/local/cuda/lib64/libcudart.so`).
 Such a link might not exist in some old container images, causing an error message at NCCL startup which mentions that `libcudart.so` could not be found.
 
-In these cases, we suggest the following paths to work around or solve the issue:
+In these cases, we suggest the following alternatives (pick one) to work around or solve the issue:
 
 1. Use a statically linked AWS OFI NCCL plugin variant from the natively installed host libraries, e.g. for a CUDA 13 image:
    ```toml

--- a/docs/software/container-engine/known-issue.md
+++ b/docs/software/container-engine/known-issue.md
@@ -111,6 +111,7 @@ abc
 
 Notice the section `[annotations]` disabling Slurm and CXI hooks.
 
+[](){#ref-known-issue-dynamic-aws-nccl-plugin}
 ## NCCL errors with a dynamically linked AWS OFI NCCL plugin: `libcudart.so could not be found`
 
 When using the `cuda-dl` variant of the [AWS OFI NCCL hook][ref-ce-aws-ofi-hook] or `artifact` as [network stack source][ref-ce-netstack-source] (default in some vClusters), a dynamically linked AWS OFI NCCL plugin is mounted inside containers.

--- a/docs/software/container-engine/known-issue.md
+++ b/docs/software/container-engine/known-issue.md
@@ -111,6 +111,31 @@ abc
 
 Notice the section `[annotations]` disabling Slurm and CXI hooks.
 
+## NCCL errors with a dynamically linked AWS OFI NCCL plugin: `libcudart.so could not be found`
+
+When using the `cuda-dl` variant of the [the AWS OFI NCCL hook][ref-ce-aws-ofi-hook] or `artifact` as [network stack source][ref-ce-netstack-source] (default in some vClusters), a dynamically linked AWS OFI NCCL plugin is mounted inside containers.
+Dynamic linking makes the plugin interoperable across CUDA versions, but also reliant on a non-versioned symlink to the CUDA Runtime Library (e.g. `/usr/local/cuda/lib64/libcudart.so`).
+Such a link might not exist in some old container images, causing an error message at NCCL startup which mentions that `libcudart.so` could not be found.
+
+In these cases, we suggest the following paths to work around or solve the issue:
+
+1. Use a statically linked AWS OFI NCCL plugin variant from the natively installed host libraries, e.g. for a CUDA 13 image:
+   ```toml
+   [annotations]
+   com.hooks.netstack.source = "host"
+   com.hooks.aws_ofi_nccl.enabled = "true"
+   com.hooks.aws_ofi_nccl.variant = "cuda13"    # (1)!
+   ```
+
+   1. When using a statically linked plugin, the variant must match exactly the CUDA version in the container.
+
+2. Rebuild the container image and use a new CUDA base image which has `libcudart.so`
+
+3. Create a `libcudart.so` at runtime, e.g. for a CUDA 12 image:
+   ```console
+   $ srun --environment=example.toml bash -c 'ln -s /usr/local/cuda/lib64/libcudart.so.12 /usr/local/cuda/lib64/libcudart.so && app_binary arg1 arg2'
+   ```
+
 ## Using NCCL from remote SSH terminals
 
 We are aware of an issue when enabling both [the AWS OFI NCCL hook][ref-ce-aws-ofi-hook] and [the SSH hook][ref-ce-ssh-hook], and launching programs using NCCL from Bash sessions connected via SSH.
@@ -119,7 +144,7 @@ The issue manifests with messages reporting `Error: network 'AWS Libfabric' not 
 In addition to setting up a server for remote connections, the SSH hook also performs actions intended to improve the user experience. One of these is creating a script to be loaded by Bash in order to propagate the container job environment variables when connecting through SSH.
 The script is translating the value of the `NCCL_NET` variable as `"'AWS Libfabric'"`, that is with additional quotes compared to the original value set by the AWS OFI NCCL hook. The quoted string induces NCCL to look for a network which is not defined, resulting in the unrecoverable error mentioned earlier.
 
-As a workaround, resetting the NCCL_NET variable to the correct value is effective in allowing NCCL to use the AWS OFI plugin and access the Slingshot network, e.g. `export NCCL_NET="AWS Libfabric"`.
+As a workaround, resetting the `NCCL_NET` variable to the correct value is effective in allowing NCCL to use the AWS OFI plugin and access the Slingshot network, e.g. `export NCCL_NET="AWS Libfabric"`.
 
 ## Mounting home directories when using the SSH hook
 
@@ -144,7 +169,7 @@ To avoid any unexpected confusion, users are advised **not** to use `--environme
 [](){#ref-ce-no-user-id}
 ## Container start fails with `id: cannot find name for user ID`
 
-If your slurm job using a container fails to start with an error message similar to:
+If your Slurm job using a container fails to start with an error message similar to:
 ```console
 slurmstepd: error: pyxis: container start failed with error code: 1
 slurmstepd: error: pyxis: container exited too soon

--- a/docs/software/container-engine/known-issue.md
+++ b/docs/software/container-engine/known-issue.md
@@ -113,7 +113,7 @@ Notice the section `[annotations]` disabling Slurm and CXI hooks.
 
 ## NCCL errors with a dynamically linked AWS OFI NCCL plugin: `libcudart.so could not be found`
 
-When using the `cuda-dl` variant of the [the AWS OFI NCCL hook][ref-ce-aws-ofi-hook] or `artifact` as [network stack source][ref-ce-netstack-source] (default in some vClusters), a dynamically linked AWS OFI NCCL plugin is mounted inside containers.
+When using the `cuda-dl` variant of the [AWS OFI NCCL hook][ref-ce-aws-ofi-hook] or `artifact` as [network stack source][ref-ce-netstack-source] (default in some vClusters), a dynamically linked AWS OFI NCCL plugin is mounted inside containers.
 Dynamic linking makes the plugin interoperable across CUDA versions, but also reliant on a non-versioned symlink to the CUDA Runtime Library (e.g. `/usr/local/cuda/lib64/libcudart.so`).
 Such a link might not exist in some old container images, causing an error message at NCCL startup which mentions that `libcudart.so` could not be found.
 

--- a/docs/software/container-engine/resource-hook.md
+++ b/docs/software/container-engine/resource-hook.md
@@ -351,7 +351,7 @@ The hook can be activated by setting the `com.hooks.nvidia_cuda_mps.enabled` to 
 [](){#ref-ce-netstack-source}
 ### Selecting the network stack source
 
-The [CXI hook][ref-ce-cxi-hook] and [AWS OFI NCCL hook][ref-ce-aws-ofi-hook] inject a set of specialized network libraries, extensions, and dependencies. These components allow containers to use the Alps Slingshot interconnect transparently and efficiently.
+The [CXI hook][ref-ce-cxi-hook] and [AWS OFI NCCL hook][ref-ce-aws-ofi-hook] inject a set of specialized network libraries, extensions, and dependencies (more details [here][ref-software-communication]). These components allow containers to use the Alps Slingshot interconnect transparently and efficiently.
 
 For convenience, we refer to one such interdependent set of networking-related software as a **network stack**, or *netstack* for short.
 
@@ -386,9 +386,6 @@ Network stack artifacts are built independently by CSCS staff for use with conta
 
     Network stack artifacts are currently fully tested and supported only on GH200 vClusters connected to the [Capstor Store][ref-alps-capstor-store] filesystem.
     Availability will be expanded progressively.
-
-!!! warning
-    Currently, netstack artifacts may not be compatible with the Slurm usage inside a containerized SBATCH script (e.g., `srun` inside `sbatch` with `--environment`).
 
 
 [](){#ref-ce-netstack-artifacts}

--- a/docs/software/container-engine/resource-hook.md
+++ b/docs/software/container-engine/resource-hook.md
@@ -215,7 +215,7 @@ Also see [NCCL][ref-communication-nccl] and [libfabric][ref-communication-libfab
 The Container Engine includes a hook program to inject the AWS OFI NCCL plugin in containers; since the plugin must also be compatible with the GPU programming software stack being used, the `com.hooks.aws_ofi_nccl.variant` annotation is used to specify a plugin variant suitable for a given container image.
 At the moment of writing, the following plugin variants are configured:
 * For NVIDIA GPU nodes: `cuda12`, `cuda13`, `cuda-dl`.
-  The `cuda-dl` variant uses a plugin which is dynamically linked to CUDA, therefore being portable across versions, and is the generally recommended choice. Some issues may arise with old container images which don't provide generic symlinks to the CUDA Runtime (more details  [here]()).
+  The `cuda-dl` variant uses a plugin which is dynamically linked to CUDA, therefore being portable across versions, and is the generally recommended choice. Some issues may arise with old container images which don't provide generic symlinks to the CUDA Runtime (more details [here](ref-known-issue-dynamic-aws-nccl-plugin)).
   The numbered variants are statically linked against a specific CUDA version and must be matched exactly with containers providing a corresponding CUDA installation.
 * For AMD GPU nodes, alongside RCCL: `rocm5`, and `rocm6`.
   Both these variants are statically linked to specific ROCm versions.

--- a/docs/software/container-engine/resource-hook.md
+++ b/docs/software/container-engine/resource-hook.md
@@ -204,7 +204,7 @@ The hook is activated by setting the `com.hooks.cxi.enabled` annotation, which 
 
 ```toml
 com.hooks.aws_ofi_nccl.enabled = "true"
-com.hooks.aws_ofi_nccl.variant = "cuda12"   # (1)!
+com.hooks.aws_ofi_nccl.variant = "cuda-dl"   # (1)!
 ```
 
 1. `com.hooks.aws_ofi_nccl.variant` may vary depending on vClusters. Details below.
@@ -213,22 +213,28 @@ The [AWS OFI NCCL plugin](https://github.com/aws/aws-ofi-nccl) is a software ex
 Also see [NCCL][ref-communication-nccl] and [libfabric][ref-communication-libfabric] for more information on using the libraries on Alps.
 
 The Container Engine includes a hook program to inject the AWS OFI NCCL plugin in containers; since the plugin must also be compatible with the GPU programming software stack being used, the `com.hooks.aws_ofi_nccl.variant` annotation is used to specify a plugin variant suitable for a given container image.
-At the moment of writing, 4 plugin variants are configured: `cuda11`, `cuda12` (to be used on NVIDIA GPU nodes), `rocm5`, and `rocm6` (to be used on AMD GPU nodes alongside RCCL).
+At the moment of writing, the following plugin variants are configured:
+* For NVIDIA GPU nodes: `cuda12`, `cuda13`, `cuda-dl`.
+  The `cuda-dl` variant uses a plugin which is dynamically linked to CUDA, therefore being portable across versions, and is the generally recommended choice. Some issues may arise with old container images which don't provide generic symlinks to the CUDA Runtime (more details  [here]()).
+  The numbered variants are statically linked against a specific CUDA version and must be matched exactly with containers providing a corresponding CUDA installation.
+* For AMD GPU nodes, alongside RCCL: `rocm5`, and `rocm6`.
+  Both these variants are statically linked to specific ROCm versions.
+
 
 !!! tip
-    It implicitly enables the [CXI hook][ref-ce-cxi-hook], therefore exposing the Slingshot interconnect to container applications. In other words, when enabling the AWS OFI NCCL hook, it's unnecessary to also enable the CXI hook separately in the EDF.
+    The hook implicitly enables the [CXI hook][ref-ce-cxi-hook], therefore exposing the Slingshot interconnect to container applications. In other words, when enabling the AWS OFI NCCL hook, it's unnecessary to also enable the CXI hook separately in the EDF.
 
 !!! note
-    It sets environment variables to control the behavior of NCCL and the libfabric CXI provider for Slingshot. In particular, the `NCCL_NET_PLUGIN` variable ([link](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#nccl-net-plugin)) is set to force NCCL to load the specific network plugin mounted by the hook. This is useful because certain container images (for example, those from NGC repositories) might already ship with a default NCCL plugin. Other environment variables help prevent application stalls and improve performance when using GPUDirect for RDMA communication.
+    The hook sets environment variables to control the behavior of NCCL and the libfabric CXI provider for Slingshot, helping prevent application stalls and improving performance, especially when using GPUDirect for RDMA communication.
 
-!!! example "EDF for the NGC PyTorch 22.12 image with Cuda 11"
+!!! example "EDF for the NGC PyTorch 25.11 image with CUDA 13.1"
     ```toml
-    image = "nvcr.io#nvidia/pytorch:22.12-py3"
+    image = "nvcr.io/nvidia/pytorch:25.11-py3"
     mounts = ["/capstor/scratch/cscs/${USER}:/capstor/scratch/cscs/${USER}"]
 
     [annotations]
     com.hooks.aws_ofi_nccl.enabled = "true"
-    com.hooks.aws_ofi_nccl.variant = "cuda11"
+    com.hooks.aws_ofi_nccl.variant = "cuda-dl"
     ```
 
 [](){#ref-ce-ssh-hook}
@@ -302,7 +308,7 @@ The hook can be activated by setting the `com.hooks.nvidia_cuda_mps.enabled` to 
 
 !!! example "Using the CUDA MPS hook"
     ```toml title="EDF: vectoradd-cuda-mps.toml"
-    image = "nvcr.io#nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0-ubuntu22.04"
+    image = "nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0-ubuntu22.04"
 
     [annotations]
     com.hooks.nvidia_cuda_mps.enabled = "true"
@@ -315,7 +321,7 @@ The hook can be activated by setting the `com.hooks.nvidia_cuda_mps.enabled` to 
 
 ??? example "Available GPUs and oversubscription error *without* the CUDA MPS hook"
     ```toml title="EDF: vectoradd-cuda.toml"
-    image = "nvcr.io#nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0-ubuntu22.04"   # (1)!
+    image = "nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0-ubuntu22.04"   # (1)!
     ```
 
     1. This EDF uses the CUDA vector addition sample from NVIDIA's NGC catalog.


### PR DESCRIPTION
Update content about AWS OFI NCCL plugin and containers, in particular:
- update plugin variants supported by the CE;
- Introduce and explain dynamically-linked plugins;
- Add known issue about dynamically-linked plugins with images missing generic `libcudart.so` links.

This PR requires #413 because it references a navigation label in the new Known Issue.