### PR TITLE
Minor fixes to CE

### DIFF
--- a/docs/software/container-engine/known-issue.md
+++ b/docs/software/container-engine/known-issue.md
@@ -134,7 +134,7 @@ In these cases, we suggest the following alternatives (pick one) to work around 
 
 3. Create a `libcudart.so` at runtime, e.g. for a CUDA 12 image:
     ```console
-    $ srun --environment=example.toml bash -c 'ln -s /usr/local/cuda/lib64/libcudart.so.12 /usr/local/cuda /lib64/libcudart.so && app_binary arg1 arg2'
+    $ srun --environment=example.toml bash -c 'ln -s /usr/local/cuda/lib64/libcudart.so.12 /usr/local/cuda/lib64/libcudart.so && app_binary arg1 arg2'
     ```
 
 ## Using NCCL from remote SSH terminals

--- a/docs/software/container-engine/known-issue.md
+++ b/docs/software/container-engine/known-issue.md
@@ -121,21 +121,21 @@ Such a link might not exist in some old container images, causing an error messa
 In these cases, we suggest the following alternatives (pick one) to work around or solve the issue:
 
 1. Use a statically linked AWS OFI NCCL plugin variant from the natively installed host libraries, e.g. for a CUDA 13 image:
-   ```toml
-   [annotations]
-   com.hooks.netstack.source = "host"
-   com.hooks.aws_ofi_nccl.enabled = "true"
-   com.hooks.aws_ofi_nccl.variant = "cuda13"    # (1)!
-   ```
+    ```toml
+    [annotations]
+    com.hooks.netstack.source = "host"
+    com.hooks.aws_ofi_nccl.enabled = "true"
+    com.hooks.aws_ofi_nccl.variant = "cuda13"    # (1)!
+    ```
 
-   1. When using a statically linked plugin, the variant must match exactly the CUDA version in the container.
+    1. When using a statically linked plugin, the variant must match exactly the CUDA version in the container.
 
 2. Rebuild the container image and use a new CUDA base image which has `libcudart.so`
 
 3. Create a `libcudart.so` at runtime, e.g. for a CUDA 12 image:
-   ```console
-   $ srun --environment=example.toml bash -c 'ln -s /usr/local/cuda/lib64/libcudart.so.12 /usr/local/cuda/lib64/libcudart.so && app_binary arg1 arg2'
-   ```
+    ```console
+    $ srun --environment=example.toml bash -c 'ln -s /usr/local/cuda/lib64/libcudart.so.12 /usr/local/cuda /lib64/libcudart.so && app_binary arg1 arg2'
+    ```
 
 ## Using NCCL from remote SSH terminals
 

--- a/docs/software/container-engine/resource-hook.md
+++ b/docs/software/container-engine/resource-hook.md
@@ -217,13 +217,13 @@ At the moment of writing, the following plugin variants are configured:
 
 * For NVIDIA GPU nodes: `cuda12`, `cuda13`, `cuda-dl`.
 
-  The `cuda-dl` variant uses a plugin which is dynamically linked to CUDA, therefore being portable across versions, and is the generally recommended choice. Some issues may arise with old container images which don't provide generic symlinks to the CUDA Runtime (more details [here][ref-known-issue-dynamic-aws-nccl-plugin]).
+    The `cuda-dl` variant uses a plugin which is dynamically linked to CUDA, therefore being portable across versions, and is the generally recommended choice. Some issues may arise with old container images which don't provide generic symlinks to the CUDA Runtime (more details [here][ref-known-issue-dynamic-aws-nccl-plugin]).
 
-  The numbered variants are statically linked against a specific CUDA version and must be matched exactly with containers providing a corresponding CUDA installation.
+    The numbered variants are statically linked against a specific CUDA version and must be matched exactly with containers providing a corresponding CUDA installation.
 
 * For AMD GPU nodes, alongside RCCL: `rocm5`, and `rocm6`.
 
-  Both these variants are statically linked to specific ROCm versions.
+    Both these variants are statically linked to specific ROCm versions.
 
 
 !!! tip

--- a/docs/software/container-engine/resource-hook.md
+++ b/docs/software/container-engine/resource-hook.md
@@ -214,10 +214,15 @@ Also see [NCCL][ref-communication-nccl] and [libfabric][ref-communication-libfab
 
 The Container Engine includes a hook program to inject the AWS OFI NCCL plugin in containers; since the plugin must also be compatible with the GPU programming software stack being used, the `com.hooks.aws_ofi_nccl.variant` annotation is used to specify a plugin variant suitable for a given container image.
 At the moment of writing, the following plugin variants are configured:
+
 * For NVIDIA GPU nodes: `cuda12`, `cuda13`, `cuda-dl`.
-  The `cuda-dl` variant uses a plugin which is dynamically linked to CUDA, therefore being portable across versions, and is the generally recommended choice. Some issues may arise with old container images which don't provide generic symlinks to the CUDA Runtime (more details [here](ref-known-issue-dynamic-aws-nccl-plugin)).
+
+  The `cuda-dl` variant uses a plugin which is dynamically linked to CUDA, therefore being portable across versions, and is the generally recommended choice. Some issues may arise with old container images which don't provide generic symlinks to the CUDA Runtime (more details [here][ref-known-issue-dynamic-aws-nccl-plugin]).
+
   The numbered variants are statically linked against a specific CUDA version and must be matched exactly with containers providing a corresponding CUDA installation.
+
 * For AMD GPU nodes, alongside RCCL: `rocm5`, and `rocm6`.
+
   Both these variants are statically linked to specific ROCm versions.
 
 


### PR DESCRIPTION
- Fix formatting of the AWS OFI NCCL hook section, so that variants are now correctly displayed as a bullet list, instead of a monolithic inline paragraph.
- Fixed incorrect formatting for reflink in AWS OFI NCCL hook section.
- Fix formatting of the numbered list in the dynamic AWS plugin known issue so that the annotation in the code block gets rendered correctly.