### PR TITLE
Linkify libfabric manpage URL

### DIFF
--- a/docs/clusters/daint.md
+++ b/docs/clusters/daint.md
@@ -178,7 +178,7 @@ Exceptional and non-disruptive updates may happen outside this time frame and wi
     FI_MR_CACHE_MAX_COUNT="524288" (previously unset)
     FI_CXI_SAFE_DEVMEM_COPY_THRESHOLD="16777216" (previously unset)
     ```
-    Information about the variables can be found at: https://ofiwg.github.io/libfabric/v2.3.0/man/fi_cxi.7.html
+    Information about the variables can be found at [https://ofiwg.github.io/libfabric/v2.3.0/man/fi_cxi.7.html](https://ofiwg.github.io/libfabric/v2.3.0/man/fi_cxi.7.html).
 
     Our testing has shown performance gains from these new defaults. Please contact us if you observe any performance degradation. 
 


### PR DESCRIPTION
The bare `https://...` doesn't become a clickable hyperlink. Change it to a proper hyperlink.