### PR TITLE
Add standalone coding agents guide

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -342,6 +342,7 @@ spglib
 sphericart
 spla
 squashfs
+srt
 srun
 ssh
 sshservice

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -154,6 +154,7 @@ acfdt
 acl
 admin
 admins
+agentic
 artifactory
 autodetection
 aws
@@ -328,6 +329,7 @@ rowspan
 rpath
 runtime
 runtimes
+sandboxing
 santis
 sbatch
 scalapack

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -46,6 +46,10 @@ We recommend running agents either on compute nodes or on your local computer wi
 When running on a compute node, [run the agent inside a container][ref-container-engine] with [only necessary directories mounted][ref-ce-edf-reference-mounts] or inside a [uenv][ref-uenv] to give the agent access to build tools and dependencies for your project.
 See the [sandboxing section][ref-coding-agents-sandboxing] below for more pointers on restricting coding agents.
 
+!!! note "uenvs do not restrict access to the host system"
+    While containers provide some isolation from the host system, uenvs provide no isolation.
+    uenvs only provide additional software on top of the host system.
+
 [](){#ref-coding-agents-sandboxing}
 ### Sandboxing
 

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -1,0 +1,90 @@
+[](){#ref-coding-agents}
+# Using coding agents on Alps
+
+Coding agents are AI-powered tools that assist with software development tasks such as writing, editing, debugging, and refactoring code.
+They can read and modify files, run build commands, and submit Slurm jobs on your behalf.
+
+This page covers Alps-specific considerations for running coding agents, regardless of which agent or LLM provider you use.
+
+!!! warning "You are responsible for actions taken by coding agents"
+    Any action taken by a coding agent you launch is your responsibility.
+    The [CSCS policies][ref-policies] apply.
+
+    In particular:
+
+    - Compute resources used by agent-launched Slurm jobs are billed to your project account.
+    - Coding agents may inadvertently submit many jobs, consume node hours, or modify files in unintended ways.
+      Not following the [Fair Usage of Shared Resources][ref-policies-fair-use] may result in access being revoked.
+    - CSCS takes no responsibility for files deleted, quotas being exhausted, or other unintended behaviour by agents.
+    - CSCS takes no responsibility for data inadvertently shared with third party LLM providers.
+
+The [LLM inference service hosted by CSCS][ref-inference-api] can be used as a provider in most coding agents.
+See the [inference API documentation][ref-inference-api-coding-agents-setup] for instructions on how to set up the most common agents to use the CSCS-hosted inference service.
+
+!!! info "Discovering best practices"
+    As agentic workflows change and improve rapidly, so do best practices.
+    To help keep this page relevant, we encourage and welcome contributions from the CSCS user community on best practices on using coding agents.
+    If you have suggestions, tips, or warnings that you'd like to share, please [get in touch with us][ref-get-in-touch], share your findings directly with other users on the [CSCS User Slack](https://cscs-users.slack.com/), or [contribute directly to the documentation][ref-contributing].
+
+[](){#ref-coding-agents-methods}
+## Running on Alps
+
+There are different ways in which one can run coding agents "on Alps":
+
+- running the agent on a login node,
+- running the agent on a compute node, or
+- running the agent locally and submitting jobs over [SSH][ref-ssh] and [Slurm][ref-slurm] or via [FirecREST][ref-firecrest].
+
+We recommend _not_ running agents on login nodes because of the potential for unintended high resource usage on a shared resource.
+However, even when not running on login nodes other resources are limited and care should be taken for example to not:
+
+- overload the [filesystems][ref-storage-fs],
+- overload the Slurm scheduler with many small jobs, or
+- submit excessive network requests from Alps.
+
+We recommend running agents either on compute nodes (if your development or workflow environment is containerized, [run the agent inside the container][ref-container-engine] with [only necessary directories mounted][ref-ce-edf-reference-mounts]) or on your local computer with limited Slurm or FirecREST jobs allowed.
+See the [sandboxing section][ref-coding-agents-sandboxing] below for more pointers on restricting coding agents.
+
+[](){#ref-coding-agents-sandboxing}
+### Sandboxing
+
+Most agents will by default only have read or write access to files within the working directory in which the agent is launched.
+This provides a basic level of protection against unwanted and irreversible actions done by agents.
+Sandboxing can provide stronger protection.
+
+We highly recommend consulting your coding agent's documentation for instructions on how to restrict commands and filesystem access. See for example:
+
+- Claude Code documentation on [sandboxing](https://code.claude.com/docs/en/sandbox-environments) or [permissions](https://code.claude.com/docs/en/permissions)
+- Opencode documentation on [permissions](https://opencode.ai/docs/permissions)
+
+We recommend starting with restrictive permissions and progressively whitelisting or approving commands manually as you get to know the behaviour of your particular coding agent and model on Alps.
+This is particularly important if you are new to coding agents, but is important even if you have used them in the past and are moving workflows to Alps.
+
+!!! info "Anthropic srt uenv"
+    On the [daint cluster][ref-cluster-daint] a preview [uenv][ref-uenv] containing the [Anthropic Sandbox Runtime (srt)](https://github.com/anthropic-experimental/sandbox-runtime) is available in the `build::` namespace:
+    
+    ```console
+    $ uenv image find build::srt
+    uenv                 arch   system  id                size(MB)  date
+    srt/26.4:2590682466  gh200  daint   ae6b951e8de7276f     969    2026-06-10
+    $ uenv image pull build::srt
+    $ uenv start srt/26.4 --view=srt
+    $ srt curl "anthropic.com" # if configured appropriately
+    Connection blocked by network allowlist
+    ```
+    
+    See the [srt documentation](https://github.com/anthropic-experimental/sandbox-runtime) for more information on configuring the sandbox.
+    
+!!! warning "Slurm does not propagate sandbox restrictions"
+    Sandboxing agents is effective for the agent process and its tool calls on the particular node where the agent is running.
+    When an agent submits a Slurm job, the restrictions of the sandbox are typically not propagated to the compute nodes of the Slurm job, resulting in the agent having broader access than the sandbox would indicate.
+    
+    We are investigating alternatives for improving the integration with Slurm.
+
+!!! todo "Provide more concrete examples of sandboxing and useful permissions configurations on Alps"
+
+[](){#ref-coding-agents-support}
+## Getting help
+
+For issues with coding agent tools (Claude Code, OpenCode, etc.), consult their respective documentation.
+If you have concerns about whether a particular agentic workflow is acceptable to run on Alps, [contact us for more information](https://support.cscs.ch).

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -16,7 +16,7 @@ This page covers Alps-specific considerations for running coding agents, regardl
     - Coding agents may inadvertently submit many jobs, consume node hours, or modify files in unintended ways.
       Not following the [Fair Usage of Shared Resources][ref-policies-fair-use] may result in access being revoked.
     - CSCS takes no responsibility for files deleted, quotas being exhausted, or other unintended behaviour by agents.
-    - CSCS takes no responsibility for data inadvertently shared with third party LLM providers.
+    - CSCS takes no responsibility for data inadvertently shared by your agent with third party LLM providers.
 
 The [LLM inference service hosted by CSCS][ref-inference-api] can be used as a provider in most coding agents.
 See the [inference API documentation][ref-inference-api-coding-agents-setup] for instructions on how to set up the most common agents to use the CSCS-hosted inference service.

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -56,7 +56,7 @@ Sandboxing can provide stronger protection.
 We highly recommend consulting your coding agent's documentation for instructions on how to restrict commands and filesystem access. See for example:
 
 - Claude Code documentation on [sandboxing](https://code.claude.com/docs/en/sandbox-environments) or [permissions](https://code.claude.com/docs/en/permissions)
-- Opencode documentation on [permissions](https://opencode.ai/docs/permissions)
+- OpenCode documentation on [permissions](https://opencode.ai/docs/permissions)
 
 We recommend starting with restrictive permissions and progressively whitelisting or approving commands manually as you get to know the behaviour of your particular coding agent and model on Alps.
 This is particularly important if you are new to coding agents, but is important even if you have used them in the past and are moving workflows to Alps.

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -35,7 +35,7 @@ Coding agents can be run on Alps in different ways:
 - running the agent on a compute node, or
 - running the agent locally and submitting jobs over [SSH][ref-ssh] and [Slurm][ref-slurm] or via [FirecREST][ref-firecrest].
 
-We recommend _not_ running agents on login nodes because of the potential for unintended high resource usage on a shared resource.
+We ask _not_ running agents on login nodes because of the potential for unintended high resource usage on a shared resource.
 However, even when not running on login nodes other resources are limited and care should be taken for example to not:
 
 - overload the [filesystems][ref-storage-fs],

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -29,7 +29,7 @@ See the [inference API documentation][ref-inference-api-coding-agents-setup] for
 [](){#ref-coding-agents-methods}
 ## Running on Alps
 
-There are different ways in which one can run coding agents "on Alps":
+Coding agents can be run on Alps in different ways:
 
 - running the agent on a login node,
 - running the agent on a compute node, or
@@ -48,8 +48,8 @@ See the [sandboxing section][ref-coding-agents-sandboxing] below for more pointe
 [](){#ref-coding-agents-sandboxing}
 ### Sandboxing
 
-Most agents will by default only have read or write access to files within the working directory in which the agent is launched.
-This provides a basic level of protection against unwanted and irreversible actions done by agents.
+Most agents will by default give access only to files within the working directory in which the agent is launched.
+This provides a basic level of protection against unwanted and irreversible actions taken by agents.
 Sandboxing can provide stronger protection.
 
 We highly recommend consulting your coding agent's documentation for instructions on how to restrict commands and filesystem access. See for example:
@@ -63,13 +63,13 @@ This is particularly important if you are new to coding agents, but is important
 !!! info "Anthropic srt uenv"
     On the [daint cluster][ref-cluster-daint] a preview [uenv][ref-uenv] containing the [Anthropic Sandbox Runtime (srt)](https://github.com/anthropic-experimental/sandbox-runtime) is available in the `build::` namespace:
     
-    ```console
+    ```console title="Pulling and using the srt uenv"
     $ uenv image find build::srt
     uenv                 arch   system  id                size(MB)  date
     srt/26.4:2590682466  gh200  daint   ae6b951e8de7276f     969    2026-06-10
     $ uenv image pull build::srt
     $ uenv start srt/26.4 --view=srt
-    $ srt curl "anthropic.com" # if configured appropriately
+    $ srt curl "anthropic.com"
     Connection blocked by network allowlist
     ```
     

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -42,7 +42,8 @@ However, even when not running on login nodes other resources are limited and ca
 - overload the Slurm scheduler with many small jobs, or
 - submit excessive network requests from Alps.
 
-We recommend running agents either on compute nodes (if your development or workflow environment is containerized, [run the agent inside the container][ref-container-engine] with [only necessary directories mounted][ref-ce-edf-reference-mounts]) or on your local computer with limited Slurm or FirecREST jobs allowed.
+We recommend running agents either on compute nodes or on your local computer with limited Slurm or FirecREST jobs allowed.
+When running on a compute node, [run the agent inside a container][ref-container-engine] with [only necessary directories mounted][ref-ce-edf-reference-mounts] or inside a [uenv][ref-uenv] to give the agent access to build tools and dependencies for your project.
 See the [sandboxing section][ref-coding-agents-sandboxing] below for more pointers on restricting coding agents.
 
 [](){#ref-coding-agents-sandboxing}

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -4,3 +4,31 @@
 Documentation that provides best practices, practical tips, known problems and useful background information.
 
 The guides are grouped around top-level topics.
+
+<div class="grid cards" markdown>
+
+-   :fontawesome-solid-robot: __Coding Agents__
+
+    Set up and use coding agents such as Claude Code and OpenCode on Alps through the LLM Inference API.
+
+    [:octicons-arrow-right-24: Coding Agents][ref-coding-agents]
+
+-   :fontawesome-solid-globe: __Internet Access__
+
+    How internet access works on Alps, including login nodes, compute nodes, and external services.
+
+    [:octicons-arrow-right-24: Internet Access on Alps][ref-guides-internet-access]
+
+-   :fontawesome-solid-hard-drive: __Storage__
+
+    Best practices for managing data across different file systems.
+
+    [:octicons-arrow-right-24: Storage][ref-guides-storage]
+
+-   :fontawesome-solid-circle-question: __Getting Support__
+
+    How to write effective support tickets and get help.
+
+    [:octicons-arrow-right-24: Support Guide][ref-guide-support]
+
+</div>

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -142,23 +142,18 @@ The service is accessed through the gateway base URL `https://llm-proxy.svc.cscs
     Describe API support.
     If we provide both OpenAI and Anthropic APIs, is it sufficient to provide links to external documentation for these APIs, with notes about any differences?
 
-[](){#ref-inference-api-guides}
-## Guides
+## Reducing consumption
 
-### Setting up coding agents to use the inference service
+* Longer prompts increase cost and latency
+* Future costs may differentiate across models with different computational load
 
-Below are instructions for setting up [Claude Code](https://claude.com/product/claude-code) and [OpenCode](https://opencode.ai).
-For more details and for other agents, see their respective documentation pages.
+[](){#ref-inference-api-coding-agents-setup}
+## Setting up coding agents to use the inference service
 
-!!! info
-    Both agent frameworks can be launched inside a loaded [uenv][ref-uenv] or [container][ref-container-engine], which will allow the agents to build and run your project.
+Below are instructions for setting up [Claude Code](https://claude.com/product/claude-code) and [OpenCode](https://opencode.ai) to use the inference service.
+For more information on using coding agents on Alps, see the [coding agents guide][ref-coding-agents].
 
-!!! warning
-    The agents will have access to to your files and are able to submit jobs on behalf of you.
-    This has to be handled very carefully; as a user you are responsible for the actions of the agents that you launch.
-    Compute resources used by agent-launched Slurm jobs will be billed towards your project account.
-
-#### Claude Code
+### Claude Code
 
 Set the following environment variables before starting a `claude` session.
 
@@ -169,7 +164,7 @@ export ANTHROPIC_MODEL=Apertus-70B-Instruct-2509
 claude
 ```
 
-#### OpenCode
+### OpenCode
 
 Add a custom provider to your OpenCode config file (typically `~/.config/opencode/opencode.json`).
 
@@ -200,11 +195,6 @@ Once connected, you can choose models configured in the config.
 !!! info
     OpenCode does not auto-discover available models.
     Models have to be explicitly configured in the config.
-
-### Reducing consumption
-
-* Longer prompts increase cost and latency
-* Future costs may differentiate across models with different computational load
 
 [](){#ref-inference-api-issues}
 ## Known issues and limitations

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -142,10 +142,12 @@ The service is accessed through the gateway base URL `https://llm-proxy.svc.cscs
     Describe API support.
     If we provide both OpenAI and Anthropic APIs, is it sufficient to provide links to external documentation for these APIs, with notes about any differences?
 
-## Reducing consumption
+## Reducing token consumption
 
 * Longer prompts increase cost and latency
 * Future costs may differentiate across models with different computational load
+
+!!! todo "This section needs expansion or removal, this is not unique to the CSCS inference API"
 
 [](){#ref-inference-api-coding-agents-setup}
 ## Setting up coding agents to use the inference service

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -167,6 +167,7 @@ nav:
     - 'Creating a new account': accounts/account-create.md
   - 'Guides':
     - guides/index.md
+    - 'Coding Agents on Alps': guides/coding-agents.md
     - 'Internet Access on Alps': guides/internet-access.md
     - 'Storage': guides/storage.md
     - 'Support Guide': guides/getting-support.md


### PR DESCRIPTION
Adds what is in my opinion the essentials, i.e. the user is ultimately responsible for what their agents do, but tries to make a start on more practical tips for users.

I'd especially like feedback from service managers (@anfink, @twrobinson, @fawzi, @kraushm, Andrea (what's your username!?) on the "You are responsible section" in the intro.

The sandboxing section is far from complete, but I currently don't have more advice to add there. If someone has suggestions for additions that they already know of, let's add it. Otherwise I'd say let's populate it when we learn more about best practices?

I also added cards to the guides page.

The inference API page is mostly stripped down, but still contains the instructions on setting up the inference endpoint with claude code and opencode. I'm unsure whether the "Reducing token consumption" section is valuable to leave (it's a big topic, and not unique to Alps or the inference service; I'm not sure we can cover it in a useful way here).