### PR TITLE
Polishing inference docs

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -136,6 +136,7 @@ SHMEM
 SHS
 SLA
 SLO
+SOTA
 SSHService
 STMV
 Scopi

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -15,6 +15,9 @@ However, CSCS collects infrastructure metrics and telemetry, including prompt an
 
 The [CSCS policies][ref-policies] apply to users of the inference service.
 
+For use of coding agents on and around Alps, see the [coding agents on Alps guide][ref-coding-agents].
+The inference API [can be used with most coding agents][ref-inference-api-coding-agents-setup].
+
 <div class="grid cards" markdown>
 -   <p style="text-align:center">Visit <a href="https://inference.status.cscs.ch/">inference.status.cscs.ch</a> for the status of the inference service, models, and latest announcements.</p>
 </div>

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -1,8 +1,6 @@
 [](){#ref-inference-api}
 # LLM Inference API Service
 
-[](){#ref-inference-api-beta}
-
 The LLM Inference API service provides [OpenAI](https://developers.openai.com/api/reference/overview)/[Anthropic](https://platform.claude.com/docs/en/api/overview)-compatible inference endpoints backed by selected open-weight LLM models such as [Apertus](https://apertvs.ai/) and other vetted models.
 Users consume tokens from a shared pool of models where requests are efficiently routed across shared serving capacity. CSCS takes care of deploying, patching, scaling, and operating the underlying serving stack.
 
@@ -11,6 +9,9 @@ If you are interested to deploy a model that is not available in this service, w
 
 Privacy and confidentiality are essential to us. CSCS does not record user prompts or model responses, and your data does not leave the infrastructure we control. Nevertheless, including sensitive data in your prompts is not allowed. CSCS collects infrastructure metrics and telemetry, including prompt and response lengths, to monitor service quality.
 
+<div class="grid cards" markdown>
+-   <p style="text-align:center">Visit <a href="https://inference.status.cscs.ch/">inference.status.cscs.ch</a> for the status of the inference service, models, and latest announcements.</p>
+</div>
 
 ## Service at a glance
 

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -2,12 +2,18 @@
 # LLM Inference API Service
 
 The LLM Inference API service provides [OpenAI](https://developers.openai.com/api/reference/overview)/[Anthropic](https://platform.claude.com/docs/en/api/overview)-compatible inference endpoints backed by selected open-weight LLM models such as [Apertus](https://apertvs.ai/) and other vetted models.
-Users consume tokens from a shared pool of models where requests are efficiently routed across shared serving capacity. CSCS takes care of deploying, patching, scaling, and operating the underlying serving stack.
+The service focuses on providing a small set of curated models over every possible model for every use case.
+If you are interested in deploying a model that is not available in this service, we encourage using the [sml tool](https://github.com/swiss-ai/model-launch) developed by the Swiss AI community.
+CSCS will also regularly reevaluate the models provided to make sure the best possible models are available.
 
-In order to maximize utilization and reduce costs, a reduced set of models is available. Because most of these models are trained by others, have inherent biases, and are aligned with their creators' principles, we highly recommend always auditing their results. Private model deployment is not supported.
-If you are interested to deploy a model that is not available in this service, we encourage using the [sml tool](https://github.com/swiss-ai/model-launch) developed by the Swiss AI community.
+!!! note
+    Because most of the provided models are trained by others, have inherent biases, and are aligned with their creators' principles, we highly recommend always auditing their results.
 
-Privacy and confidentiality are essential to us. CSCS does not record user prompts or model responses, and your data does not leave the infrastructure we control. Nevertheless, including sensitive data in your prompts is not allowed. CSCS collects infrastructure metrics and telemetry, including prompt and response lengths, to monitor service quality.
+Privacy and confidentiality are essential to us.
+CSCS does not record user prompts or model responses, and your data does not leave the infrastructure we control.
+However, CSCS collects infrastructure metrics and telemetry, including prompt and response lengths, to monitor service quality.
+
+The [CSCS policies][ref-policies] apply to users of the inference service.
 
 <div class="grid cards" markdown>
 -   <p style="text-align:center">Visit <a href="https://inference.status.cscs.ch/">inference.status.cscs.ch</a> for the status of the inference service, models, and latest announcements.</p>

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -34,11 +34,14 @@ Privacy and confidentiality are essential to us. CSCS does not record user promp
   Your data is yours and is processed entirely within CSCS in Switzerland.
   Prompts and responses are not recorded.
 
+* :material-pillar: **Hosted Apertus**
+
+  The fully open [Apertus](https://apertvs.ai) model is hosted on this service.
+  We highly recommend trying it out for your workflows.
+  Apertus is built on open data, methods and alignment principles, and is compliant with the EU AI Act.
+  A global foundation to build on!
+
 </div>
-
-!!! note
-    We highly recommend using [Apertus](https://apertvs.ai/), which is available in this service. Apertus is fully open---including data, methods and alignment principles---and is compliant with the EU AI Act. A global foundation to build on!
-
 
 [](){#ref-inference-api-quickstart}
 ## Quick start

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -213,6 +213,12 @@ The following OpenAI- and Anthropic-compatible endpoints are available.
 When using the endpoints for example [through agents][ref-inference-api-coding-agents-setup], the framework will handle API requests for you.
 For information on how to use the endpoints directly, see the [OpenAI](https://developers.openai.com/api/reference/overview) and [Anthropic](https://platform.claude.com/docs/en/api/overview) documentation.
 
+[](){#ref-inference-api-available-models}
+## Available models and pricing
+
+Available models, along with pricing information, are listed on the [cscs2go Inference API page](https://2go.cscs.ch/offering/swiss_academia/#inference-api).
+The available models can also be listed for a given API key using the [`models` endpoint][ref-inference-api-endpoints] or on the Inference API UI page when creating a new key.
+
 [](){#ref-inference-api-coding-agents-setup}
 ## Setting up coding agents to use the inference service
 


### PR DESCRIPTION
I made apertus it's own card in the service at a glance, it's a bit more visible this way. It's also a "foundation" with a "pillar" icon and sits at the bottom of the list, so too many metaphors to even count.

I reworked the intro a bit to hopefully flow a bit better. The first paragraph focuses on the service and the models, and mentioning the sml tool for self hosted models. The next paragraph focuses on not recording prompts and collecting infrastructure metrics.

I removed the explicit "sensitive data not allowed" and link to the policies instead in a separate paragraph.

I added another explicit link to the coding agents guide and setting up coding agents with the inference service to the intro as well to highlight it a bit better.

Some of these are definitely subjective changes, so I welcome feedback. Some things I might have gone too far, and some not far enough. Let me know what you think.