### PR TITLE
Inference API pricing and status page links

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -137,6 +137,7 @@ SHS
 Skybox
 SLA
 SLO
+SOTA
 SSHService
 STMV
 Scopi

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -11,6 +11,9 @@ If you are interested to deploy a model that is not available in this service, w
 
 Privacy and confidentiality are essential to us. CSCS does not record user prompts or model responses, and your data does not leave the infrastructure we control. Nevertheless, including sensitive data in your prompts is not allowed. CSCS collects infrastructure metrics and telemetry, including prompt and response lengths, to monitor service quality.
 
+<div class="grid cards" markdown>
+-   <p style="text-align:center">Visit <a href="https://inference.status.cscs.ch/">inference.status.cscs.ch</a> for the status of the inference service, models, and latest announcements.</p>
+</div>
 
 ## Service at a glance
 

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -155,6 +155,12 @@ curl -X POST "https://api.inference.cscs.ch/v1/chat/completions" \
 [](){#ref-inference-api-access}
 ## Access
 
+[](){#ref-inference-api-available-models}
+### Available models and pricing
+
+Available models, along with pricing information, are listed on the [cscs2go Inference API page](https://2go.cscs.ch/offering/swiss_academia/#inference-api).
+The available models can also be listed for a given API key using the [`models` endpoint][ref-inference-api-endpoints] or on the Inference API UI page when creating a new key.
+
 [](){#ref-inference-api-access-resource}
 ### Create an inference resource
 
@@ -202,12 +208,6 @@ The following OpenAI- and Anthropic-compatible endpoints are available.
 
 When using the endpoints for example [through agents][ref-inference-api-coding-agents-setup], the framework will handle API requests for you.
 For information on how to use the endpoints directly, see the [OpenAI](https://developers.openai.com/api/reference/overview) and [Anthropic](https://platform.claude.com/docs/en/api/overview) documentation.
-
-[](){#ref-inference-api-available-models}
-## Available models and pricing
-
-Available models, along with pricing information, are listed on the [cscs2go Inference API page](https://2go.cscs.ch/offering/swiss_academia/#inference-api).
-The available models can also be listed for a given API key using the [`models` endpoint][ref-inference-api-endpoints] or on the Inference API UI page when creating a new key.
 
 [](){#ref-inference-api-coding-agents-setup}
 ## Setting up coding agents to use the inference service

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -203,6 +203,12 @@ The following OpenAI- and Anthropic-compatible endpoints are available.
 When using the endpoints for example [through agents][ref-inference-api-coding-agents-setup], the framework will handle API requests for you.
 For information on how to use the endpoints directly, see the [OpenAI](https://developers.openai.com/api/reference/overview) and [Anthropic](https://platform.claude.com/docs/en/api/overview) documentation.
 
+[](){#ref-inference-api-available-models}
+## Available models and pricing
+
+Available models, along with pricing information, are listed on the [cscs2go Inference API page](https://2go.cscs.ch/offering/swiss_academia/#inference-api).
+The available models can also be listed for a given API key using the [`models` endpoint][ref-inference-api-endpoints] or on the Inference API UI page when creating a new key.
+
 [](){#ref-inference-api-coding-agents-setup}
 ## Setting up coding agents to use the inference service
 

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -1,3 +1,7 @@
+<div class="grid cards" markdown>
+-   <p style="text-align:center">Visit <a href="https://inference.status.cscs.ch/">inference.status.cscs.ch</a> for the status of the inference service, models, and latest announcements.</p>
+</div>
+
 [](){#ref-inference-api}
 # LLM Inference API Service
 
@@ -10,10 +14,6 @@ In order to maximize utilization and reduce costs, a reduced set of models is av
 If you are interested to deploy a model that is not available in this service, we encourage using the [sml tool](https://github.com/swiss-ai/model-launch) developed by the Swiss AI community.
 
 Privacy and confidentiality are essential to us. CSCS does not record user prompts or model responses, and your data does not leave the infrastructure we control. Nevertheless, including sensitive data in your prompts is not allowed. CSCS collects infrastructure metrics and telemetry, including prompt and response lengths, to monitor service quality.
-
-<div class="grid cards" markdown>
--   <p style="text-align:center">Visit <a href="https://inference.status.cscs.ch/">inference.status.cscs.ch</a> for the status of the inference service, models, and latest announcements.</p>
-</div>
 
 ## Service at a glance
 


### PR DESCRIPTION
Splitting out the pricing, models, and status page links from #446.