### PR TITLE
Document self-service and Service Desk paths for inference resource creation

### DIFF
--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -169,6 +169,13 @@ The available models can also be listed for a given API key using the [`models` 
 An inference resource must be created for your project before any project member can create API keys.
 The PI or deputy PI can do this in one of two ways, depending on the allocation type of your project.
 
+In both cases the resource is assigned a number of node hours drawn from your project's allocation.
+These node hours are deducted from the allocation and converted into inference credits for the resource; see the [institutional pricing page](https://2go.cscs.ch/offering/swiss_academia/institutional_customers/) for the current node-hour rate.
+
+??? example "worked example (rate as of 1 July 2026)"
+    At the node-hour rate of CHF 2.69 in effect on 1 July 2026, allocating 2,000 node hours corresponds to CHF 5,380 of inference credits.
+    Always check the [institutional pricing page](https://2go.cscs.ch/offering/swiss_academia/institutional_customers/) for the current rate.
+
 === "Self-service"
     The PI or deputy PI can create the inference resource directly in the [project management portal][ref-account-waldur]:
 
@@ -187,11 +194,6 @@ The PI or deputy PI can do this in one of two ways, depending on the allocation 
 
     !!! warning "node hours are required"
         We cannot process the request without the number of node hours to allocate.
-        The node hours you specify are deducted from your allocation and converted into inference credits for the resource; see the [institutional pricing page](https://2go.cscs.ch/offering/swiss_academia/institutional_customers/) for the current node-hour rate.
-
-    ??? example "worked example (rate as of 1 July 2026)"
-        At the node-hour rate of CHF 2.69 in effect on 1 July 2026, allocating 2,000 node hours corresponds to CHF 5,380 of inference credits.
-        Always check the [institutional pricing page](https://2go.cscs.ch/offering/swiss_academia/institutional_customers/) for the current rate.
 
 [](){#ref-inference-api-access-key}
 ### Create an API key

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -187,7 +187,11 @@ The PI or deputy PI can do this in one of two ways, depending on what is availab
 
     !!! warning "node hours are required"
         We cannot process the request without the number of node hours to allocate.
-        On [Clariden][ref-cluster-clariden], one node hour costs CHF 2.69, and the node hours you specify are converted into inference credits for the resource.
+        The node hours you specify are converted into inference credits for the resource; see the [institutional pricing page](https://2go.cscs.ch/offering/swiss_academia/institutional_customers/) for the current node-hour rate.
+
+    ??? example "worked example (rate as of 1 July 2026)"
+        At the node-hour rate of CHF 2.69 in effect on 1 July 2026, allocating 2,000 node hours corresponds to CHF 5,380 of inference credits.
+        Always check the [institutional pricing page](https://2go.cscs.ch/offering/swiss_academia/institutional_customers/) for the current rate.
 
 [](){#ref-inference-api-access-key}
 ### Create an API key

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -167,9 +167,9 @@ The available models can also be listed for a given API key using the [`models` 
 ### Create an inference resource
 
 An inference resource must be created for your project before any project member can create API keys.
-The path you use depends on your project's allocation type: for some projects the PI or deputy PI can create the resource directly in the project management portal (self-service), while others must request it through the CSCS Service Desk.
+The procedure you use depends on your project's allocation type: for some projects the PI or deputy PI can create the resource directly in the project management portal (self-service), while others must request it through the CSCS Service Desk.
 
-=== "Self-service"
+=== "Self-service (SwissAI)"
     The PI or deputy PI can create the inference resource directly in the [project management portal][ref-account-waldur]:
 
     - Click the "Add resource" button in the top left of the UI.
@@ -180,20 +180,17 @@ The path you use depends on your project's allocation type: for some projects th
 
     If you are a project member, ask your PI or deputy PI to create the resource for you.
 
-=== "Service Desk"
-    If self-service is not available for your project (you cannot find the `inference-api-u` offering), open a ticket at the [CSCS Service Desk](https://support.cscs.ch) with the following details:
+=== "Service Desk (other organizations)"
+    As self-service is not available for your project, the PI or Deputy PI should create a ticket at the [CSCS Service Desk](https://support.cscs.ch) with the following details:
 
     - Service: Inference Service
     - Request: add an inference resource to project `<your project ID>`
-    - Node hours to assign to the resource: `<amount>`
+    - Node hours to assign to the resource: `<amount>` from `<cluster>`
 
-    The node hours you specify are deducted from your project's node hours and converted into inference credits for the resource; see the [institutional pricing page](https://2go.cscs.ch/offering/swiss_academia/institutional_customers/) for the current node-hour rate.
-
-    !!! warning "node hours are required"
-        We cannot process the request without the number of node hours to allocate.
+    The node hours you specify are deducted from your project's node hours on `<cluster>` and converted into inference credits for the resource; see the [institutional pricing page](https://2go.cscs.ch/offering/swiss_academia/institutional_customers/) for the current node-hour rate.
 
     ??? example "worked example (rate as of 1 July 2026)"
-        At the node-hour rate of CHF 2.69 in effect on 1 July 2026, allocating 2,000 node hours corresponds to CHF 5,380 of inference credits.
+        At the node-hour rate of CHF 2.69 in effect on 1 July 2026, allocating 2,000 node hours on Daint (Grace-Hopper) corresponds to CHF 5,380 of inference credits.
         Always check the [institutional pricing page](https://2go.cscs.ch/offering/swiss_academia/institutional_customers/) for the current rate.
 
 [](){#ref-inference-api-access-key}

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -167,7 +167,7 @@ The available models can also be listed for a given API key using the [`models` 
 ### Create an inference resource
 
 An inference resource must be created for your project before any project member can create API keys.
-The procedure you use depends on your project's allocation type: for some projects the PI or deputy PI can create the resource directly in the project management portal (self-service), while others must request it through the CSCS Service Desk.
+Which procedure applies depends on the organization your project belongs to: projects in the SwissAI organization can create the resource directly in the project management portal (self-service), while projects from other organizations must request it through the CSCS Service Desk.
 
 === "Self-service (SwissAI)"
     The PI or deputy PI can create the inference resource directly in the [project management portal][ref-account-waldur]:

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -167,14 +167,7 @@ The available models can also be listed for a given API key using the [`models` 
 ### Create an inference resource
 
 An inference resource must be created for your project before any project member can create API keys.
-The PI or deputy PI can do this in one of two ways, depending on the allocation type of your project.
-
-In both cases the resource is assigned a number of node hours drawn from your project's allocation.
-These node hours are deducted from the allocation and converted into inference credits for the resource; see the [institutional pricing page](https://2go.cscs.ch/offering/swiss_academia/institutional_customers/) for the current node-hour rate.
-
-??? example "worked example (rate as of 1 July 2026)"
-    At the node-hour rate of CHF 2.69 in effect on 1 July 2026, allocating 2,000 node hours corresponds to CHF 5,380 of inference credits.
-    Always check the [institutional pricing page](https://2go.cscs.ch/offering/swiss_academia/institutional_customers/) for the current rate.
+The path you use depends on your project's allocation type: for some projects the PI or deputy PI can create the resource directly in the project management portal (self-service), while others must request it through the CSCS Service Desk.
 
 === "Self-service"
     The PI or deputy PI can create the inference resource directly in the [project management portal][ref-account-waldur]:
@@ -183,6 +176,8 @@ These node hours are deducted from the allocation and converted into inference c
     - Select your project from the dropdown.
     - Choose the "Inference Service" category and the `inference-api-u` offering.
 
+    The credit for the inference resource is taken from your project's credit.
+
     If you are a project member, ask your PI or deputy PI to create the resource for you.
 
 === "Service Desk"
@@ -190,10 +185,16 @@ These node hours are deducted from the allocation and converted into inference c
 
     - Service: Inference Service
     - Request: add an inference resource to project `<your project ID>`
-    - Node hours to assign to the resource, drawn from your project's allocation: `<amount>`
+    - Node hours to assign to the resource: `<amount>`
+
+    The node hours you specify are deducted from your project's node hours and converted into inference credits for the resource; see the [institutional pricing page](https://2go.cscs.ch/offering/swiss_academia/institutional_customers/) for the current node-hour rate.
 
     !!! warning "node hours are required"
         We cannot process the request without the number of node hours to allocate.
+
+    ??? example "worked example (rate as of 1 July 2026)"
+        At the node-hour rate of CHF 2.69 in effect on 1 July 2026, allocating 2,000 node hours corresponds to CHF 5,380 of inference credits.
+        Always check the [institutional pricing page](https://2go.cscs.ch/offering/swiss_academia/institutional_customers/) for the current rate.
 
 [](){#ref-inference-api-access-key}
 ### Create an API key

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -152,17 +152,34 @@ curl -X POST "https://api.inference.cscs.ch/v1/chat/completions" \
 [](){#ref-inference-api-access}
 ## Access
 
+Access to the inference service is granted at the project level.
+There are two ways to enable it, depending on your project.
+
 [](){#ref-inference-api-access-resource}
 ### Create an inference resource
 
-The PI or deputy PI of your project must first create an inference resource in the [project management portal][ref-account-waldur]:
+An inference resource must be created for your project before any project member can create API keys.
+The PI or deputy PI can do this in one of two ways, depending on what is available for your project.
 
-- Click the "Add resource" button in the top left of the UI.
-- Select your project from the dropdown.
-- Choose the "Inference Service" category and the "Inference API" offering.
+=== "Self-service"
+    The PI or deputy PI can create the inference resource directly in the [project management portal][ref-account-waldur]:
 
-!!! note
-    If you are a project member, ask your PI to create the inference resource first.
+    - Click the "Add resource" button in the top left of the UI.
+    - Select your project from the dropdown.
+    - Choose the "Inference Service" category and the "Inference API" offering.
+
+    If you are a project member, ask your PI or deputy PI to create the resource for you.
+
+=== "Service Desk"
+    If self-service is not available for your project, open a ticket at the [CSCS Service Desk](https://support.cscs.ch) with the following details:
+
+    - Service: Inference Service
+    - Request: add an inference resource to project `<your project ID>`
+    - Node hours to allocate to the resource: `<amount>`
+
+    !!! warning "node hours are required"
+        We cannot process the request without the number of node hours to allocate.
+        On [Clariden][ref-cluster-clariden], one node hour costs CHF 2.69, and the node hours you specify are converted into inference credits for the resource.
 
 [](){#ref-inference-api-access-key}
 ### Create an API key

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -167,27 +167,27 @@ The available models can also be listed for a given API key using the [`models` 
 ### Create an inference resource
 
 An inference resource must be created for your project before any project member can create API keys.
-The PI or deputy PI can do this in one of two ways, depending on what is available for your project.
+The PI or deputy PI can do this in one of two ways, depending on the allocation type of your project.
 
 === "Self-service"
     The PI or deputy PI can create the inference resource directly in the [project management portal][ref-account-waldur]:
 
     - Click the "Add resource" button in the top left of the UI.
     - Select your project from the dropdown.
-    - Choose the "Inference Service" category and the "Inference API" offering.
+    - Choose the "Inference Service" category and the `inference-api-u` offering.
 
     If you are a project member, ask your PI or deputy PI to create the resource for you.
 
 === "Service Desk"
-    If self-service is not available for your project, open a ticket at the [CSCS Service Desk](https://support.cscs.ch) with the following details:
+    If self-service is not available for your project (you cannot find the `inference-api-u` offering), open a ticket at the [CSCS Service Desk](https://support.cscs.ch) with the following details:
 
     - Service: Inference Service
     - Request: add an inference resource to project `<your project ID>`
-    - Node hours to allocate to the resource: `<amount>`
+    - Node hours to assign to the resource, drawn from your project's allocation: `<amount>`
 
     !!! warning "node hours are required"
         We cannot process the request without the number of node hours to allocate.
-        The node hours you specify are converted into inference credits for the resource; see the [institutional pricing page](https://2go.cscs.ch/offering/swiss_academia/institutional_customers/) for the current node-hour rate.
+        The node hours you specify are deducted from your allocation and converted into inference credits for the resource; see the [institutional pricing page](https://2go.cscs.ch/offering/swiss_academia/institutional_customers/) for the current node-hour rate.
 
     ??? example "worked example (rate as of 1 July 2026)"
         At the node-hour rate of CHF 2.69 in effect on 1 July 2026, allocating 2,000 node hours corresponds to CHF 5,380 of inference credits.


### PR DESCRIPTION
Reworks the **Access** section of the inference API page to explain that an inference resource can be enabled in two ways, depending on the project:

- **Self-service** — the PI or deputy PI creates the resource directly in the project management portal
- **Service Desk** — for projects where self-service is not available, by opening a ticket with the service, request, and node hours to allocate

The two paths are presented as content tabs. A warning admonition highlights that the number of node hours is required for a Service Desk request. Rather than hardcoding a price, it links the institutional pricing page for the current node-hour rate, with a folded, explicitly dated worked example (2,000 node hours → CHF 5,380 at the 1 July 2026 rate).
