### PR TITLE
Add apiKey to OpenCode configuration

### DIFF
--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -253,12 +253,14 @@ Add a custom provider to your OpenCode config file (typically `~/.config/opencod
 ```json title="OpenCode configuration for the inference API"
 {
   "$schema": "https://opencode.ai/config.json",
+  "model": "cscs/moonshotai/Kimi-K2.7-Code",
   "provider": {
     "cscs": {
       "npm": "@ai-sdk/openai-compatible",
       "name": "CSCS Inference",
       "options": {
-        "baseURL": "https://api.inference.cscs.ch/v1"
+        "baseURL": "https://api.inference.cscs.ch/v1",
+        "apiKey": "{env:CSCS_INFERENCE_API_KEY}" 
       },
       "models": {
         "moonshotai/Kimi-K2.7-Code": {

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -261,6 +261,7 @@ Add a custom provider to your OpenCode config file (typically `~/.config/opencod
       "name": "CSCS Inference",
       "options": {
         "baseURL": "https://api.inference.cscs.ch/v1",
+        // Set apiKey or use /connect after configuring the provider
         "apiKey": "{env:CSCS_INFERENCE_API_KEY}" 
       },
       "models": {

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -253,6 +253,7 @@ Add a custom provider to your OpenCode config file (typically `~/.config/opencod
 ```json title="OpenCode configuration for the inference API"
 {
   "$schema": "https://opencode.ai/config.json",
+   // Set Kimi as default OpenCode model
   "model": "cscs/moonshotai/Kimi-K2.7-Code",
   "provider": {
     "cscs": {


### PR DESCRIPTION
Add apiKey configuration for CSCS Inference provider.  Set a model explicitly.