### PR TITLE
Add announcements section linking the inference Slack channel

### DIFF
--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -285,7 +285,7 @@ Once connected, you can choose models configured in the config.
 ## Announcements
 
 Planned maintenance, incidents, and changes to the available models are published on the [service status page](https://inference.status.cscs.ch).
-Everyone with access to a project that has an inference resource is subscribed automatically and can unsubscribe at any time.
+Everyone with access to a project that has an inference resource is subscribed automatically and can opt out at any time.
 
 The same announcements are also posted in the `#inference-service` channel of the CSCS User Slack; see [get in touch][ref-get-in-touch] to join.
 

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -284,8 +284,10 @@ Once connected, you can choose models configured in the config.
 [](){#ref-inference-api-announcements}
 ## Announcements
 
-Service announcements, including planned maintenance and changes to the available models, are posted in the `#inference-service` channel of the CSCS User Slack.
-See [get in touch][ref-get-in-touch] to join the Slack workspace.
+Planned maintenance, incidents, and changes to the available models are published on the [service status page](https://inference.status.cscs.ch).
+Everyone with access to a project that has an inference resource is subscribed automatically and can unsubscribe at any time.
+
+The same announcements are also posted in the `#inference-service` channel of the CSCS User Slack; see [get in touch][ref-get-in-touch] to join.
 
 [](){#ref-inference-api-issues}
 ## Known issues and limitations

--- a/docs/services/inference/api.md
+++ b/docs/services/inference/api.md
@@ -279,6 +279,12 @@ Once connected, you can choose models configured in the config.
     Models have to be explicitly configured in the config.
     Use the `/v1/models` endpoint to list available models for your key.
 
+[](){#ref-inference-api-announcements}
+## Announcements
+
+Service announcements, including planned maintenance and changes to the available models, are posted in the `#inference-service` channel of the CSCS User Slack.
+See [get in touch][ref-get-in-touch] to join the Slack workspace.
+
 [](){#ref-inference-api-issues}
 ## Known issues and limitations
 


### PR DESCRIPTION
Adds a short **Announcements** section to the inference API page pointing users to the `#inference-service` channel of the CSCS User Slack for service announcements (planned maintenance, model changes).

It links the existing get-in-touch section to join the Slack workspace rather than duplicating the join instructions, following the same pattern used for the per-cluster channels (e.g. `#eiger`).