### PR TITLE
Cpe container 26.3

### DIFF
--- a/docs/clusters/bristen.md
+++ b/docs/clusters/bristen.md
@@ -2,9 +2,9 @@
 # Bristen
 
 Bristen is an Alps cluster that provides GPU accelerators and filesystems designed to meet the needs of machine learning workloads in the [MLP][ref-platform-mlp].
-It is clasified as a test and development system, provided on a best effort basis for benchmarking and testing [a100][ref-alps-a100-node] nodes, data preparation and similar tasks that require x86 nodes.
+It is classified as a test and development system, provided on a best effort basis for benchmarking and testing [a100][ref-alps-a100-node] nodes, data preparation and similar tasks that require x86 nodes.
 It is *not* a  cluster where to do the bulk of your computation, nodes can be removed from it for higher priority tasks.
-[Clariden](../clariden) is where production runs should take place. 
+[Clariden][ref-cluster-clariden] is where production runs should take place. 
 
 ## Cluster Specification
 

--- a/docs/software/prgenv/cpe.md
+++ b/docs/software/prgenv/cpe.md
@@ -12,11 +12,8 @@ The CPE is a suite of software: programming environments, compilers, libraries a
 The CPE will be familiar to users of previous CSCS systems, including Piz Daint, and users of HPE/Cray systems at other sites.
 It provides modules for programming environments including `Prgenv-gnu` and `Prgenv-cray`, and packages like `cray-python` and `cray-fftw`.
 
-
-!!! Warning "The `cray` module is deprecated"
-    [Eiger][ref-cluster-eiger] currently has CPE 24.7 installed. This version is outdated and can be loaded using the `cray` module.
-
-    * This module will be removed on August 26th 2026
+!!! Warning "The `cray` module is no longer available"
+    The `cray` module on [Eiger][ref-cluster-eiger] was removed on August 26th, 2026.
 
     The recommended method for building and running software is to use [uenv][ref-uenv] or [containers][ref-container-engine].
     See the [programming environment][ref-software-prgenvs] documentation for alternative programming environments.

--- a/docs/software/prgenv/cpe.md
+++ b/docs/software/prgenv/cpe.md
@@ -45,7 +45,9 @@ The `PrgEnv-gnu` and `PrgEnv-cray` programming environments are provided as sepa
 | `cpe-cray-24.7` | ✅       | ✅      |
 | `cpe-gnu-25.3`  | ✅       | ✅      |
 | `cpe-cray-25.3` | ✅       | ✅      |
+| `cpe-gnu-25.9`  | ✅       | ✅      |
 | `cpe-cray-25.9` | ✅       | ✅      |
+| `cpe-gun-26.3 ` | ✅       | ✅      |
 | `cpe-cray-26.3` | ✅       | ✅      |
 
 !!! note "CPE 26.3 is the last CPE release"

--- a/docs/software/prgenv/cpe.md
+++ b/docs/software/prgenv/cpe.md
@@ -48,7 +48,7 @@ The `PrgEnv-gnu` and `PrgEnv-cray` programming environments are provided as sepa
 | `cpe-cray-26.3` | ✅       | ✅      |
 
 !!! note "CPE 26.3 is the last CPE release"
-    HPE have announced that they 26.3 is the last release of CPE.
+    HPE have announced that 26.3 is the last release of CPE.
 
     HPE Supercomputing Programming Software (SUPS) will be the replacement.
     CSCS will provide software packages from SUPS in [uenv][ref-uenv].

--- a/docs/software/prgenv/cpe.md
+++ b/docs/software/prgenv/cpe.md
@@ -13,11 +13,10 @@ The CPE will be familiar to users of previous CSCS systems, including Piz Daint,
 It provides modules for programming environments including `Prgenv-gnu` and `Prgenv-cray`, and packages like `cray-python` and `cray-fftw`.
 
 
-??? Warning "The `cray` module is deprecated"
-    [Eiger][ref-cluster-eiger] currently has CPE 24.7 installed. This version is outdated and can be loaded using the `cray` module. 
+!!! Warning "The `cray` module is deprecated"
+    [Eiger][ref-cluster-eiger] currently has CPE 24.7 installed. This version is outdated and can be loaded using the `cray` module.
 
-    * This module will be removed in mid 2026 
-    * CSCS won't provide support when the `cray` module is loaded.
+    * This module will be removed on August 26th 2026
 
     The recommended method for building and running software is to use [uenv][ref-uenv] or [containers][ref-container-engine].
     See the [programming environment][ref-software-prgenvs] documentation for alternative programming environments.
@@ -46,6 +45,14 @@ The `PrgEnv-gnu` and `PrgEnv-cray` programming environments are provided as sepa
 | `cpe-cray-24.7` | ✅       | ✅      |
 | `cpe-gnu-25.3`  | ✅       | ✅      |
 | `cpe-cray-25.3` | ✅       | ✅      |
+| `cpe-cray-25.9` | ✅       | ✅      |
+| `cpe-cray-26.3` | ✅       | ✅      |
+
+!!! note "CPE 26.3 is the last CPE release"
+    HPE have announced that they 26.3 is the last release of CPE.
+
+    HPE Supercomputing Programming Software (SUPS) will be the replacement.
+    CSCS will provide software packages from SUPS in [uenv][ref-uenv].
 
 ??? question "Where are CPE containers stored?"
 


### PR DESCRIPTION
- update CPE container docs to cover all versions provided on daint/eiger
- update date and time for CPE module removal
- drive by fix of broken link and spelling in Bristen docs.