### PR TITLE
Improve zensical search styling

### DIFF
--- a/docs/javascripts/search-styling.js
+++ b/docs/javascripts/search-styling.js
@@ -1,0 +1,209 @@
+/*
+ * Stop-gap styling for the search overlay.
+ *
+ * Zensical builds the search dialog at runtime and mounts it in an open shadow
+ * root attached to a bare <div> at the end of <body>, so neither zensical.toml
+ * nor docs/stylesheets/extra.css can reach it. See the TODO under
+ * [project.plugins.search] in zensical.toml: this file should be removed once
+ * zensical ships hooks for styling the search interface.
+ *
+ * The class names inside the shadow root are minified and are regenerated on
+ * every zensical release, so nothing here refers to them. Instead we walk the
+ * tree down from the search <input> and tag the structural elements with our
+ * own data-cscs-search attributes, and the injected stylesheet targets those.
+ * If the structure ever changes the walk bails out and the stock styling is
+ * left untouched.
+ *
+ * Colours are read from the --color-* custom properties that zensical defines
+ * in the light DOM. Those inherit through the shadow boundary, so the palette
+ * is tuned in docs/stylesheets/extra.css and stays scheme-aware for free.
+ */
+(function () {
+  "use strict";
+
+  var STYLES = [
+    /* base font size, for anything that does not set its own */
+    '[data-cscs-search="root"] { --font-size: 19px; }',
+
+    /* backdrop: a real dim, so the page clearly reads as "behind" */
+    '[data-cscs-search="backdrop"] {',
+    '  background-color: rgb(var(--color-backdrop) / 0.55);',
+    '}',
+
+    /* panel: opaque, bordered and lifted off the page */
+    '[data-cscs-search="panel"] {',
+    '  background-color: rgb(var(--color-background));',
+    '  border: 1px solid rgb(var(--color-foreground) / 0.18);',
+    '  box-shadow: 0 1.5rem 4rem rgb(0 0 0 / 0.35);',
+    '}',
+
+    /* input: a recessed field with an accent focus ring */
+    '[data-cscs-search="input"] {',
+    '  padding: 6px 10px;',
+    '  border-radius: var(--border-radius-2);',
+    '  background-color: rgb(var(--color-background-subtle));',
+    '  box-shadow: inset 0 0 0 1px rgb(var(--color-foreground) / 0.12);',
+    '  transition: box-shadow 0.15s ease;',
+    '}',
+    '[data-cscs-search="input"]:focus-within {',
+    '  box-shadow: inset 0 0 0 2px var(--md-accent-fg-color, #526cfe);',
+    '}',
+    '[data-cscs-search="input"] input {',
+    '  font-size: 19px;',
+    '  letter-spacing: normal;',
+    '}',
+
+    /* the controls row already separates itself with the field background */
+    '[data-cscs-search="controls"] { border-bottom: none; }',
+    '[data-cscs-search="results"] {',
+    '  border-top: 1px solid rgb(var(--color-foreground) / 0.12);',
+    '  color: rgb(var(--color-foreground) / 0.86);',
+    '}',
+
+    /* results typography */
+    '[data-cscs-search="results"] h3 { font-size: 15px; }',
+    '[data-cscs-search="results"] h2 { font-size: 18px; }',
+    '[data-cscs-search="results"] h2 code { font-size: 17px; }',
+    '[data-cscs-search="results"] menu li {',
+    '  font-size: 15px;',
+    '  color: rgb(var(--color-foreground) / 0.62);',
+    '}',
+    '[data-cscs-search="results"] h2 + div { font-size: 16px; }',
+    '[data-cscs-search="results"] h2 + div code { font-size: 15px; }',
+    /* code spans get their own tint rather than --color-background-subtle,
+       which also drives the input field and the hover band and so has to sit
+       much lighter than the panel in dark mode */
+    '[data-cscs-search="results"] code {',
+    '  background-color: rgb(var(--color-foreground) / 0.06);',
+    '}',
+
+    /* filters sidebar: part of the panel, so opaque like the panel */
+    '[data-cscs-search="sidebar"] {',
+    '  background-color: rgb(var(--color-background-subtle));',
+    '}',
+    '[data-cscs-search="sidebar"] h3 { font-size: 19px; }',
+    '[data-cscs-search="sidebar"] h4 { font-size: 17px; }',
+    '[data-cscs-search="sidebar"] li { font-size: 15px; }'
+  ].join("\n");
+
+  /* Tag the structural elements of the dialog. Returns false and changes
+     nothing if the tree does not have the shape we expect. */
+  function tag(shadowRoot) {
+    var input = shadowRoot.querySelector('input[role="combobox"]') ||
+                shadowRoot.querySelector("input");
+    if (!input) {
+      return false;
+    }
+
+    var field    = input.parentElement;
+    var controls = field && field.parentElement;
+    var content  = controls && controls.parentElement;
+    var panel    = content && content.parentElement;
+    var root     = panel && panel.parentElement;
+    if (!root || root.parentNode !== shadowRoot) {
+      return false;
+    }
+
+    var backdrop = root.firstElementChild;
+    var results  = controls.nextElementSibling;
+    var sidebar  = content.nextElementSibling;
+    if (backdrop === panel) {
+      backdrop = null;
+    }
+
+    var parts = {
+      root: root,
+      backdrop: backdrop,
+      panel: panel,
+      content: content,
+      controls: controls,
+      input: field,
+      results: results,
+      sidebar: sidebar
+    };
+    Object.keys(parts).forEach(function (name) {
+      if (parts[name]) {
+        parts[name].setAttribute("data-cscs-search", name);
+      }
+    });
+    return true;
+  }
+
+  function adopt(shadowRoot) {
+    try {
+      var sheet = new CSSStyleSheet();
+      sheet.replaceSync(STYLES);
+      shadowRoot.adoptedStyleSheets = shadowRoot.adoptedStyleSheets.concat(sheet);
+      return;
+    } catch (error) {
+      /* fall through to a plain <style> element */
+    }
+    var style = document.createElement("style");
+    style.textContent = STYLES;
+    shadowRoot.appendChild(style);
+  }
+
+  function decorate(host) {
+    var shadowRoot = host.shadowRoot;
+    adopt(shadowRoot);
+    tag(shadowRoot);
+
+    /* The host is attached as soon as the search component mounts, but its
+       contents are only rendered once the search index arrives from the
+       worker, so the first tag() above usually finds nothing. The dialog is
+       also re-rendered on every keystroke. Re-tag on mutation, both to catch
+       that first render and so a future rewrite cannot silently drop the
+       tags. Only childList is observed, so our own setAttribute calls cannot
+       feed back into this. */
+    var pending = false;
+    new MutationObserver(function () {
+      if (pending) {
+        return;
+      }
+      pending = true;
+      requestAnimationFrame(function () {
+        pending = false;
+        tag(shadowRoot);
+      });
+    }).observe(shadowRoot, { childList: true, subtree: true });
+  }
+
+  /* The overlay host is the only direct child of <body> with a shadow root:
+     the bundle's other attachShadow call is mermaid, which uses mode "closed"
+     on an element that is never a direct child of <body>. */
+  function findHost() {
+    var children = document.body.children;
+    for (var i = 0; i < children.length; i++) {
+      if (children[i].shadowRoot) {
+        return children[i];
+      }
+    }
+    return null;
+  }
+
+  var done = false;
+  function attempt() {
+    if (done) {
+      return true;
+    }
+    var host = findHost();
+    if (!host) {
+      return false;
+    }
+    done = true;
+    decorate(host);
+    return true;
+  }
+
+  if (!attempt()) {
+    /* The host is created when the search component mounts, which happens
+       asynchronously after the bundle loads. With navigation.instant the
+       bundle is not re-run on navigation, so this only needs to fire once. */
+    var observer = new MutationObserver(function () {
+      if (attempt()) {
+        observer.disconnect();
+      }
+    });
+    observer.observe(document.body, { childList: true });
+  }
+})();

--- a/docs/javascripts/search-styling.js
+++ b/docs/javascripts/search-styling.js
@@ -70,6 +70,24 @@
     '}',
     '[data-cscs-search="results"] h2 + div { font-size: 16px; }',
     '[data-cscs-search="results"] h2 + div code { font-size: 15px; }',
+    /* the matched term: --cscs-search-mark is set per scheme in extra.css and
+       falls back to the overlay's own accent-derived highlight colour */
+    '[data-cscs-search="results"] a mark {',
+    '  color: var(--cscs-search-mark, var(--color-highlight));',
+    '}',
+
+    /* Alternate row tints so adjacent results are easy to tell apart. The
+       hover / active band is an ::before overlay that defaults to
+       --color-background-subtle; in light mode that is only a few steps from
+       the zebra tint, so give the band its own stronger value to keep hover
+       and the top result clearly ahead of the striping. */
+    '[data-cscs-search="results"] ol > li:nth-child(even) > a {',
+    '  background-color: rgb(var(--color-foreground) / 0.065);',
+    '}',
+    '[data-cscs-search="results"] ol > li > a::before {',
+    '  background-color: rgb(var(--color-foreground) / 0.15);',
+    '}',
+
     /* code spans get their own tint rather than --color-background-subtle,
        which also drives the input field and the hover band and so has to sit
        much lighter than the panel in dark mode */

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -170,3 +170,26 @@
   display: none;
 }
 
+/* Search overlay palette.
+
+   Zensical renders the search dialog inside a shadow root, so these inherited
+   custom properties are the only part of it reachable from an ordinary style
+   sheet. Everything else is handled in docs/javascripts/search-styling.js,
+   which consumes these same variables so the overlay stays scheme-aware.
+
+   Nothing outside the search overlay reads these variables. */
+
+/* Light mode: the stock backdrop is white at 54% behind a white panel, so the
+   panel is almost invisible. Wash the page with a dark tint instead. */
+[data-md-color-scheme="default"] {
+  --color-backdrop: 18 22 30;
+}
+
+/* Dark mode: darken the backdrop, and lift the panel well clear of the page
+   colour (22 23 26) so it reads as floating rather than as part of the page. */
+[data-md-color-scheme="slate"] {
+  --color-backdrop: 0 0 0;
+  /*--color-background: 56 60 70;*/
+  --color-background: 68 73 84;
+  --color-background-subtle: 76 81 94;
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -191,5 +191,10 @@
   --color-backdrop: 0 0 0;
   /*--color-background: 56 60 70;*/
   --color-background: 68 73 84;
-  --color-background-subtle: 76 81 94;
+  /* keeps the input field and the filters sidebar lifted clear of the panel */
+  --color-background-subtle: 92 98 112;
+  /* Colour of the matched search term within a result. The accent blue the
+     overlay uses by default is hard to read against the dark panel; this pale
+     amber sits at ~6.6:1 against it. Light mode keeps the accent colour. */
+  --cscs-search-mark: #ffd479;
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-zensical
+zensical==0.0.57

--- a/zensical.toml
+++ b/zensical.toml
@@ -9,6 +9,7 @@ extra_javascript = [
   "javascripts/mathjax.js",
   "https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js",
   "javascripts/version-badges.js",
+  "javascripts/search-styling.js",
 ]
 
 nav = [
@@ -296,8 +297,11 @@ accent  = "blue"
 toggle  = {icon = "material/brightness-4", name = "Switch to auto mode"}
 
 [project.plugins.search]
-# TODO: tweak font size and border properties to increase readability
-# and contrast against background, when support is added to zensical.
+# The search dialog is rendered into a shadow root at runtime, so its font
+# sizes and contrast cannot be set from here or from extra_css. Until zensical
+# adds styling hooks, docs/javascripts/search-styling.js patches the shadow
+# root and docs/stylesheets/extra.css supplies the palette it uses.
+# TODO: drop that workaround once these are configurable here.
 
 # autorefs is built into zensical, but has to be enabled explicitly
 [project.plugins.autorefs]


### PR DESCRIPTION
The zensical search box comes with some iffy default styling:

- small fonts
- low contrast making text and regions difficult to parse visually
- clicking the search button takes focus to a different part of the screen, but it is not easy to see where you should move your focus

Zensical does not net provide hooks for customizing search look and feel, so this implements a temporary fix based on inspecting the internals of the search tool.
- it might break if the internal search tool implementation changes.