### PR TITLE
add github info and link to top RHS of each page

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -1,6 +1,8 @@
 [project]
-site_name = "CSCS Documentation"
 site_url  = "https://docs.cscs.ch/"
+site_name = "CSCS Documentation"
+repo_url = "https://github.com/eth-cscs/cscs-docs"
+repo_name = "eth-cscs/cscs-docs"
 docs_dir  = "docs"
 
 extra_css = ["stylesheets/extra.css"]


### PR DESCRIPTION
This went missing in the transition to Zensical.

<img width="483" height="102" alt="grafik" src="https://github.com/user-attachments/assets/fe7261f8-a69f-4dc8-94c4-d2800254abec" />
