### PR TITLE
remove icon from the docs

### DIFF
--- a/docs/clusters/santis.md
+++ b/docs/clusters/santis.md
@@ -55,7 +55,6 @@ Please refer to the [uenv documentation][ref-uenv] for detailed information on h
 
     Provide software stacks for climate and weather workflows on Santis.
 
-     * [ICON][ref-software-icon]
      * [netcdf-tools][ref-uenv-netcdf-tools]
 
 </div>

--- a/docs/software/cw/deployment.md
+++ b/docs/software/cw/deployment.md
@@ -8,7 +8,7 @@ The [uenv][ref-uenv] deployed on [Santis][ref-cluster-santis] and Balfrin are ge
     - [Programming environments][ref-software-prgenvs];
     - and tools including [Linaro Forge][ref-uenv-linaro].
 - **community managed** uenv recipes in the [C2SM/software-stack-recipes](https://github.com/C2SM/software-stack-recipes)
-    - [icon][ref-software-icon]
+    - `icon``
     - `climana` on Santis.
     - `fdb` uenv on the MCH systems.
 

--- a/docs/software/cw/icon.md
+++ b/docs/software/cw/icon.md
@@ -1,9 +1,0 @@
-[](){#ref-software-icon}
-# ICON
-
-[ICON](https://www.icon-model.org/) is a flexible, scalable, high-performance modelling framework for weather, climate and environmental prediction 
-
-!!! under-construction
-    The uenv images for building ICON and ICON-EXCLAIM will be released soon, and documented here.
-
-See the [C2SM documentation](https://c2sm.github.io/models/icon) for more information.

--- a/docs/software/cw/index.md
+++ b/docs/software/cw/index.md
@@ -5,10 +5,6 @@ Software for the climate research community is available on [Santis][ref-cluster
 The software is maintained in a collaboration between the climate community and CSCS.
 
 <div class="grid cards" markdown>
--   :fontawesome-solid-earth: [__ICON__][ref-software-icon]
-
-    !!! under-construction
-        uenv images for icon and icon-exclaim are being developed, and will be deployed on [Santis][ref-cluster-santis] and Balfrin (MCH) in Q1 2026.
 
 -   :fontawesome-solid-bullhorn: __Community Codes__
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -136,9 +136,8 @@ nav = [
     ]},
     {"Climate and Weather" = [
       "software/cw/index.md",
-      {"Deployment" = "software/cw/deployment.md"},
-      {"ICON" = "software/cw/icon.md"},
       {"netcdf-tools" = "software/cw/netcdf-tools.md"},
+      {"Deployment" = "software/cw/deployment.md"},
     ]},
     {"Communication Libraries" = [
       "software/communication/index.md",


### PR DESCRIPTION
Fix the problem of references to stubs for ICON docs that have not been updated since creation.

See SD-70155