### PR TITLE
fix "edit this page" links pointing at the master branch

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -1,8 +1,10 @@
 [project]
 site_url  = "https://docs.cscs.ch/"
 site_name = "CSCS Documentation"
+# Repository: link in the top right corner, and "edit this page" on each page
 repo_url = "https://github.com/eth-cscs/cscs-docs"
 repo_name = "eth-cscs/cscs-docs"
+edit_uri = "edit/main/docs/"
 docs_dir  = "docs"
 
 extra_css = ["stylesheets/extra.css"]
@@ -225,11 +227,6 @@ nav = [
     "contributing/index.md",
   ]},
 ]
-
-# Repository: link in the top right corner, and "edit this page" on each page
-[project.repo]
-url = "https://github.com/eth-cscs/cscs-docs"
-edit_uri = "edit/main/docs/"
 
 # Validation: the docs are built with --strict, so every one of these is an
 # error that fails the build.


### PR DESCRIPTION
The "edit this page" pencil on every page linked to `.../edit/master/docs/...`, a branch that no longer exists.

Zensical reads `edit_uri` as a top-level key of `[project]`. The `[project.repo]` table added in #487 is silently ignored, so `edit_uri` fell back to the built-in `edit/master/<docs_dir>` default for `github.com`. Moving `edit_uri` next to `repo_url`/`repo_name` fixes it.

Verified with `./serve build --strict`:

```
$ grep -o "https://github.com/eth-cscs/cscs-docs/edit/[^\"]*" site/index.html
https://github.com/eth-cscs/cscs-docs/edit/main/docs/index.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015N2YMpEG65mwprtBA1WZMP