### PR TITLE
Minor corrections

### DIFF
--- a/docs/access/ssh.md
+++ b/docs/access/ssh.md
@@ -273,6 +273,13 @@ Host clariden
     User cscsusername
     IdentityFile ~/.ssh/cscs-key
     IdentitiesOnly yes
+
+Host eiger
+    HostName eiger.alps.cscs.ch
+    ProxyJump ela
+    User cscsusername
+    IdentityFile ~/.ssh/cscs-key
+    IdentitiesOnly yes
 ```
 
 !!! note ""

--- a/docs/alps/hardware.md
+++ b/docs/alps/hardware.md
@@ -1,7 +1,7 @@
 [](){#ref-alps-hardware}
 # Alps Hardware
 
-Alps is a HPE Cray EX3000 system, a liquid cooled blade-based, high-density system.
+Alps is a HPE Cray EX3000 system, a liquid-cooled blade-based, high-density system.
 
 !!! under-construction
     This page is a work in progress - contact us if you want us to prioritise documentation specific information that would be useful for your work.
@@ -11,12 +11,12 @@ Alps is a HPE Cray EX3000 system, a liquid cooled blade-based, high-density syst
 The basic building block of the system is a liquid-cooled cabinet.
 A single cabinet can accommodate up to 64 compute blade slots within 8 compute chassis. The cabinet is not configured with any
 cooling fans.
-All cooling needs for the cabinet are provided by direct liquid cooling and the CDU.
-This approach to cooling provides greater efficiency for the rack-level cooling, decreases power costs associated with cooling (no blowers) and utilizes a single water source per CDU One cabinet supports the following:
+All cooling needs for the cabinet are provided by direct liquid cooling and the Coolant Distribution Unit (CDU).
+This approach to cooling provides greater efficiency for the rack-level cooling, decreases power costs associated with cooling (no blowers) and utilizes a single water source per CDU. One cabinet supports the following:
 
 * 8 compute chassis
-* 4 power shelves with a maximum of 6 rectifiers per shelf- 24 total 12.5 or 15kW rectifiers per cabinet
-* 4 PDUs (1 per power shelf)
+* 4 power shelves with a maximum of 6 rectifiers (AC to DC converters) per shelf, at a power of 12.5 or 15kW per rectifier
+* 4 Power Distribution Units (PDUs) (1 per power shelf)
 * 3 power input whips (3-phase)
 * Maximum of 64 quad-blade compute blades
 * Maximum of 64 Slingshot switch blades
@@ -57,7 +57,7 @@ There are currently five node types in Alps:
     We will add more detailed information soon.
     Please [get in touch](https://github.com/eth-cscs/cscs-docs/issues) if there is information that you want to see here.
 
-There are 24 cabinets, in 4 rows with 6 cabinets per row, and each cabinet contains 112 nodes (for a total of 448 GH200):
+There are 24 cabinets, in 4 rows with 6 cabinets per row, and each cabinet contains 112 nodes (for a total of 448 GH200 per cabinet):
 
 * 8 chassis per cabinet
 * 7 blades per chassis
@@ -93,7 +93,7 @@ Each node contains four Grace-Hopper modules and four corresponding network inte
 [](){#ref-alps-zen2-node}
 ### AMD Rome CPU Nodes
 
-These nodes have two [AMD Epyc 7742](https://en.wikichip.org/wiki/amd/epyc/7742) 64-core CPU sockets, and are used primarily for the [Eiger][ref-cluster-eiger] system. They come in two memory configurations:
+These nodes have two [AMD Epyc 7742](https://www.amd.com/en/support/downloads/drivers.html/processors/epyc/epyc-7002-series/amd-epyc-7742.html) 64-core CPU sockets, and are used primarily for the [Eiger][ref-cluster-eiger] system. They come in two memory configurations:
 
 * *Standard-memory*:  256 GB in 16x16 GB DDR4 DIMMs.
 * *Large-memory*:  512 GB in 16x32 GB DDR4 DIMMs.

--- a/docs/clusters/bristen.md
+++ b/docs/clusters/bristen.md
@@ -77,7 +77,7 @@ See the Slurm documentation for instructions on how to run jobs on the [Grace-Ho
 
 ### FirecREST
 
-Bristen can also be accessed using [FirecREST][ref-firecrest] at the `https://api.cscs.ch/ml/firecrest/v1` API endpoint.
+Bristen can also be accessed using [FirecREST][ref-firecrest] at the `https://api.cscs.ch/ml/firecrest/v2` API endpoint.
 
 ### Scheduled Maintenance
 

--- a/docs/clusters/clariden.md
+++ b/docs/clusters/clariden.md
@@ -121,7 +121,7 @@ See the Slurm documentation for instructions on how to run jobs on the [Grace-Ho
 
 ### FirecREST
 
-Clariden can also be accessed using [FirecREST][ref-firecrest] at the `https://api.cscs.ch/ml/firecrest/v1` API endpoint.
+Clariden can also be accessed using [FirecREST][ref-firecrest] at the `https://api.cscs.ch/ml/firecrest/v2` API endpoint.
 
 ## Maintenance and status
 


### PR DESCRIPTION
3 different small corrections:
- update firecREST urls (from v1 to v2) for Bristen and Clariden clusters
- add eiger to `~/.ssh/config`
- improve wording/typesetting of hardware page

Changes are here:
- https://cscs-docs-preview.svc.cscs.ch/493/clusters/bristen/#firecrest & https://cscs-docs-preview.svc.cscs.ch/493/clusters/clariden/#firecrest
- https://cscs-docs-preview.svc.cscs.ch/493/access/ssh/#adding-ela-as-a-jump-host-in-ssh-configuration
- https://cscs-docs-preview.svc.cscs.ch/493/alps/hardware/