### PR TITLE
Remove `-Cmc`  from job submission scripts

### DIFF
--- a/docs/running/slurm.md
+++ b/docs/running/slurm.md
@@ -64,9 +64,6 @@ $ sbatch --account=g123 ./job.sh
 ...
 ```
 
-!!! note
-    The flags `--account` and `-Cmc` that were required on the old [Eiger][ref-cluster-eiger] cluster are no longer required.
-
 ## Prioritisation and scheduling
 
 Job priorities are determined based on each project's resource usage relative to its quarterly allocation, as well as in comparison to other projects.

--- a/docs/services/cicd.md
+++ b/docs/services/cicd.md
@@ -295,7 +295,7 @@ make multiarch:
 run aarch64:
   extends: [.container-runner-daint-gh200, .run]
 run x86_64:
-  extends: [.container-runner-eiger-mc, .run]
+  extends: [.container-runner-eiger-zen2, .run]
 ```
 
 We first create two container images which have different names.

--- a/docs/software/sciapps/cp2k.md
+++ b/docs/software/sciapps/cp2k.md
@@ -463,7 +463,6 @@ On Eiger, a similar sbatch script can be used:
 #SBATCH --account=<ACCOUNT>
 #SBATCH --hint=nomultithread
 #SBATCH --hint=exclusive
-#SBATCH --constraint=mc
 #SBATCH --uenv=<CP2K_UENV>
 #SBATCH --view=cp2k
 

--- a/docs/software/sciapps/lammps.md
+++ b/docs/software/sciapps/lammps.md
@@ -252,7 +252,6 @@ On Eiger, the following sbatch script can be used:
 #SBATCH --account=<ACCOUNT> (4)
 #SBATCH --hint=nomultithread
 #SBATCH --hint=exclusive
-#SBATCH --constraint=mc                                                  
 #SBATCH --uenv=<LAMMPS_UENV>:/user-environment (5)
 #SBATCH --view=kokkos (6)
 

--- a/docs/software/sciapps/namd.md
+++ b/docs/software/sciapps/namd.md
@@ -233,7 +233,6 @@ The following sbatch script shows how to run NAMD on Eiger:
 #SBATCH --ntasks-per-node=64
 #SBATCH --account=<ACCOUNT> (1)
 #SBATCH --hint=nomultithread
-#SBATCH --constraint=mc
 #SBATCH --uenv=namd/3.0:v1 (2)
 #SBATCH --view=namd (3)
 

--- a/docs/software/userapps/orca.md
+++ b/docs/software/userapps/orca.md
@@ -31,7 +31,6 @@ uenv is required. Here is a sample Slurm batch script:
 #SBATCH --ntasks-per-node=64
 #SBATCH --account=<ACCOUNT>
 #SBATCH --hint=nomultithread
-#SBATCH --constraint=mc
 #SBATCH --uenv=prgenv-gnu-openmpi/25.12:v1
 #SBATCH --view=default
 
@@ -95,7 +94,6 @@ After downloading the `hq` executable, any number of ORCA jobs can be scheduled 
 #SBATCH --ntasks-per-node=128
 #SBATCH --account=<ACCOUNT>
 #SBATCH --hint=nomultithread
-#SBATCH --constraint=mc
 #SBATCH --uenv=prgenv-gnu-openmpi/25.12:v1
 #SBATCH --view=default
 


### PR DESCRIPTION
I removed the `--constraint=mc` (or `-Cmc`) from the job submission scripts.

I also removed one note that -Cmc is not needed anymore on eiger (mainly because I felt that "old" eiger is quite outdated, and not really relevant anymore, but also because there was stated that `--account` is not needed anymore, which is not true since Waldur upgrade).